### PR TITLE
move wasizero to imports/wasi_snapshot_preview1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Emacs
+*~

--- a/README.md
+++ b/README.md
@@ -9,12 +9,10 @@ This is a Go implementation of the WebAssembly System Interface ([WASI][wasi]).
 ## Package Layout
 
 - `.`: types and constants from the [WASI preview 1 specification][preview1]
-- [`wasiunix`][wasiunix]: a Unix implementation
-- [`wasizero`][wasizero]: a host module for the [wazero][wazero] runtime
+- [`wasiunix`](wasiunix): a Unix implementation
+- [`imports/wasi_snapshot_preview1`](imports/wasi_snapshot_preview1): a host module for the [wazero][wazero] runtime
 
 
 [wasi]: https://github.com/WebAssembly/WASI
 [preview1]: https://github.com/WebAssembly/WASI/blob/e324ce3/legacy/preview1/docs.md
-[wasiunix]: https://github.com/stealthrocket/wasi/tree/main/wasiunix
-[wasizero]: https://github.com/stealthrocket/wasi/tree/main/wasizero
 [wazero]: https://wazero.io

--- a/imports/wasi_snapshot_preview1/module.go
+++ b/imports/wasi_snapshot_preview1/module.go
@@ -1,4 +1,4 @@
-package wasizero
+package wasi_snapshot_preview1
 
 import (
 	"context"

--- a/wasiunix/cmd/wasiunix/main.go
+++ b/wasiunix/cmd/wasiunix/main.go
@@ -12,8 +12,8 @@ import (
 	_ "unsafe" // for go:linktime
 
 	"github.com/stealthrocket/wasi"
+	"github.com/stealthrocket/wasi/imports/wasi_snapshot_preview1"
 	"github.com/stealthrocket/wasi/wasiunix"
-	"github.com/stealthrocket/wasi/wasizero"
 	"github.com/stealthrocket/wazergo"
 	"github.com/tetratelabs/wazero"
 )
@@ -135,7 +135,10 @@ func run(args []string) error {
 		})
 	}
 
-	module := wazergo.MustInstantiate(ctx, runtime, wasizero.HostModule, wasizero.WithWASI(provider))
+	module := wazergo.MustInstantiate(ctx, runtime,
+		wasi_snapshot_preview1.HostModule,
+		wasi_snapshot_preview1.WithWASI(provider),
+	)
 	ctx = wazergo.WithModuleInstance(ctx, module)
 
 	instance, err := runtime.Instantiate(ctx, wasmCode)


### PR DESCRIPTION
People who are going to care about using this package will likely feel at home if we keep a similar directory structure to wazero's.

How about we reuse `imports/wasi_snapshot_preview1`?

Also, selfishly, this will help with my muscle memory when switching between projects :D 