### PR TITLE
make poll_oneoff resilient to invalid subscriptions

### DIFF
--- a/imports/wasi_snapshot_preview1/module.go
+++ b/imports/wasi_snapshot_preview1/module.go
@@ -392,18 +392,18 @@ func (m *Module) PathUnlinkFile(ctx context.Context, fd Int32, path String) Errn
 	return Errno(m.WASI.PathUnlinkFile(ctx, wasi.FD(fd), string(path)))
 }
 
-func (m *Module) PollOneOff(ctx context.Context, subscriptionsPtr Pointer[wasi.Subscription], eventsPtr Pointer[wasi.Event], nSubscriptions Int32, n Pointer[Int32]) Errno {
+func (m *Module) PollOneOff(ctx context.Context, in Pointer[wasi.Subscription], out Pointer[wasi.Event], nSubscriptions Int32, nEvents Pointer[Int32]) Errno {
 	if nSubscriptions <= 0 {
 		return Errno(wasi.EINVAL)
 	}
-	subscriptions := subscriptionsPtr.UnsafeSlice(int(nSubscriptions))
-	events := eventsPtr.UnsafeSlice(int(nSubscriptions))
-	var errno wasi.Errno
-	events, errno = m.WASI.PollOneOff(ctx, subscriptions, events[:0])
+	n, errno := m.WASI.PollOneOff(ctx,
+		in.UnsafeSlice(int(nSubscriptions)),
+		out.UnsafeSlice(int(nSubscriptions)),
+	)
 	if errno != wasi.ESUCCESS {
 		return Errno(errno)
 	}
-	n.Store(Int32(len(events)))
+	nEvents.Store(Int32(n))
 	return Errno(wasi.ESUCCESS)
 }
 

--- a/provider.go
+++ b/provider.go
@@ -246,10 +246,9 @@ type Provider interface {
 	//
 	// If len(subscriptions) == 0, EINVAL is returned.
 	//
-	// The function appends events to the provided []Event buffer. If there
-	// is not enough space (len(subscriptions) > cap(events)) a new
-	// buffer will be created and returned.
-	PollOneOff(ctx context.Context, subscriptions []Subscription, events []Event) ([]Event, Errno)
+	// The function writes events to the provided []Event buffer, expecting
+	// len(events)>=len(subscriptions).
+	PollOneOff(ctx context.Context, subscriptions []Subscription, events []Event) (int, Errno)
 
 	// ProcExit terminates the process normally.
 	//


### PR DESCRIPTION
This PR addresses a few TODO in the `poll_oneoff` implementation to be more resilient to invalid configurations.

I also modified the signature of `PollOneOff` to take the input and output buffers as arguments and return the number of events written to the output buffer instead of doing an `append` (same model as the default WASI); I did this to be able to correlate the indexes of subscriptions and events, which was helpful to support assigning errors to events.
