### PR TITLE
only retain file paths for preopens

### DIFF
--- a/internal/descriptor/table.go
+++ b/internal/descriptor/table.go
@@ -99,15 +99,24 @@ func (t *Table[Descriptor, Object]) Assign(desc Descriptor, object Object) (prev
 	return
 }
 
-// Lookup returns the object associated with the given descriptor,
-// which may be nil.
-func (t *Table[Descriptor, Object]) Lookup(desc Descriptor) (object Object, found bool) {
+// Access returns a pointer to the object associated with the given
+// descriptor, which may be nil if it was not found in the table.
+func (t *Table[Descriptor, Object]) Access(desc Descriptor) *Object {
 	if i := int(desc); i >= 0 && i < len(t.table) {
 		index := uint(desc) / 64
 		shift := uint(desc) % 64
 		if (t.masks[index] & (1 << shift)) != 0 {
-			object, found = t.table[i], true
+			return &t.table[i]
 		}
+	}
+	return nil
+}
+
+// Lookup returns the object associated with the given descriptor.
+func (t *Table[Descriptor, Object]) Lookup(desc Descriptor) (object Object, found bool) {
+	ptr := t.Access(desc)
+	if ptr != nil {
+		object, found = *ptr, true
 	}
 	return
 }

--- a/wasiunix/provider.go
+++ b/wasiunix/provider.go
@@ -50,7 +50,7 @@ type Provider struct {
 	// Rand is the source for RandomGet.
 	Rand io.Reader
 
-	fds      descriptor.Table[wasi.FD, *fdinfo]
+	fds      descriptor.Table[wasi.FD, fdinfo]
 	preopens descriptor.Table[wasi.FD, string]
 	pollfds  []unix.PollFd
 
@@ -79,7 +79,7 @@ func (p *Provider) Preopen(hostfd int, path string, fdstat wasi.FDStat) {
 	fdstat.RightsBase &= wasi.AllRights
 	fdstat.RightsInheriting &= wasi.AllRights
 	p.preopens.Assign(
-		p.fds.Insert(&fdinfo{
+		p.fds.Insert(fdinfo{
 			fd:   hostfd,
 			stat: fdstat,
 		}),
@@ -88,13 +88,12 @@ func (p *Provider) Preopen(hostfd int, path string, fdstat wasi.FDStat) {
 }
 
 func (p *Provider) isPreopen(fd wasi.FD) bool {
-	_, ok := p.preopens.Lookup(fd)
-	return ok
+	return p.preopens.Access(fd) != nil
 }
 
 func (p *Provider) lookupFD(guestfd wasi.FD, rights wasi.Rights) (*fdinfo, wasi.Errno) {
-	f, ok := p.fds.Lookup(guestfd)
-	if !ok {
+	f := p.fds.Access(guestfd)
+	if f == nil {
 		return nil, wasi.EBADF
 	}
 	if !f.stat.RightsBase.Has(rights) {
@@ -408,10 +407,11 @@ func (p *Provider) FDRenumber(ctx context.Context, from, to wasi.FD) wasi.Errno 
 		return errno
 	}
 	// TODO: limit max file descriptor number
-	f, replaced := p.fds.Assign(to, f)
+	g, replaced := p.fds.Assign(to, *f)
 	if replaced {
-		unix.Close(f.fd)
+		unix.Close(g.fd)
 	}
+	p.fds.Delete(from)
 	return wasi.ESUCCESS
 }
 
@@ -627,7 +627,7 @@ func (p *Provider) PathOpen(ctx context.Context, fd wasi.FD, lookupFlags wasi.Lo
 		return -1, makeErrno(err)
 	}
 
-	guestfd := p.fds.Insert(&fdinfo{
+	guestfd := p.fds.Insert(fdinfo{
 		fd: hostfd,
 		stat: wasi.FDStat{
 			FileType:         fileType,
@@ -930,7 +930,7 @@ func (p *Provider) SockAccept(ctx context.Context, fd wasi.FD, flags wasi.FDFlag
 	if err != nil {
 		return -1, makeErrno(err)
 	}
-	guestfd := p.fds.Insert(&fdinfo{
+	guestfd := p.fds.Insert(fdinfo{
 		fd: connfd,
 		stat: wasi.FDStat{
 			FileType:         wasi.SocketStreamType,
@@ -981,7 +981,7 @@ func (p *Provider) SockShutdown(ctx context.Context, fd wasi.FD, flags wasi.SDFl
 }
 
 func (p *Provider) Close(ctx context.Context) error {
-	p.fds.Range(func(fd wasi.FD, f *fdinfo) bool {
+	p.fds.Range(func(fd wasi.FD, f fdinfo) bool {
 		unix.Close(f.fd)
 		return true
 	})


### PR DESCRIPTION
Now that `fd_readdir` is not implemented with `os.ReadDir` (see #10), we can track file paths for preopens only.