### PR TITLE
extension: path_open sockets

### DIFF
--- a/cmd/wasirun/main.go
+++ b/cmd/wasirun/main.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/stealthrocket/wasi-go"
-	"github.com/stealthrocket/wasi-go/extensions"
 	"github.com/stealthrocket/wasi-go/imports/wasi_snapshot_preview1"
 	"github.com/stealthrocket/wasi-go/internal/sockets"
 	"github.com/stealthrocket/wasi-go/systems/unix"
@@ -131,7 +130,7 @@ func run(args []string) error {
 	// Setup sockets extension.
 	switch socketExt {
 	case "path_open":
-		system = &extensions.PathOpenSockets{system}
+		system = &unix.PathOpenSockets{system}
 	case "":
 	default:
 		return fmt.Errorf("unknown or unsupported socket extension: %s", socketExt)

--- a/system.go
+++ b/system.go
@@ -306,7 +306,7 @@ type System interface {
 	// Close closes the System.
 	Close(ctx context.Context) error
 
-	// Open is a lower-level variant of Preopen that registers a file
+	// Register is a lower-level variant of Preopen that registers a file
 	// descriptor.
-	Open(hostfd int, fdstat FDStat) FD
+	Register(hostfd int, fdstat FDStat) FD
 }

--- a/systems/unix/syscall_unix.go
+++ b/systems/unix/syscall_unix.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func MakeErrno(err error) wasi.Errno {
+func makeErrno(err error) wasi.Errno {
 	if err == nil {
 		return wasi.ESUCCESS
 	}

--- a/systems/unix/system.go
+++ b/systems/unix/system.go
@@ -76,10 +76,10 @@ type fdinfo struct {
 
 // Preopen adds an open file to the list of pre-opens.
 func (s *System) Preopen(hostfd int, path string, fdstat wasi.FDStat) {
-	s.preopens.Assign(s.Open(hostfd, fdstat), path)
+	s.preopens.Assign(s.Register(hostfd, fdstat), path)
 }
 
-func (s *System) Open(hostfd int, fdstat wasi.FDStat) wasi.FD {
+func (s *System) Register(hostfd int, fdstat wasi.FDStat) wasi.FD {
 	fdstat.RightsBase &= wasi.AllRights
 	fdstat.RightsInheriting &= wasi.AllRights
 	return s.fds.Insert(fdinfo{
@@ -159,13 +159,13 @@ func (s *System) ClockTimeGet(ctx context.Context, id wasi.ClockID, precision wa
 			return 0, wasi.ENOTSUP
 		}
 		t, err := s.Realtime(ctx)
-		return wasi.Timestamp(t), MakeErrno(err)
+		return wasi.Timestamp(t), makeErrno(err)
 	case wasi.Monotonic:
 		if s.Monotonic == nil {
 			return 0, wasi.ENOTSUP
 		}
 		t, err := s.Monotonic(ctx)
-		return wasi.Timestamp(t), MakeErrno(err)
+		return wasi.Timestamp(t), makeErrno(err)
 	case wasi.ProcessCPUTimeID, wasi.ThreadCPUTimeID:
 		return 0, wasi.ENOTSUP
 	default:
@@ -179,7 +179,7 @@ func (s *System) FDAdvise(ctx context.Context, fd wasi.FD, offset wasi.FileSize,
 		return errno
 	}
 	err := fdadvise(f.fd, int64(offset), int64(length), advice)
-	return MakeErrno(err)
+	return makeErrno(err)
 }
 
 func (s *System) FDAllocate(ctx context.Context, fd wasi.FD, offset wasi.FileSize, length wasi.FileSize) wasi.Errno {
@@ -188,7 +188,7 @@ func (s *System) FDAllocate(ctx context.Context, fd wasi.FD, offset wasi.FileSiz
 		return errno
 	}
 	err := fallocate(f.fd, int64(offset), int64(length))
-	return MakeErrno(err)
+	return makeErrno(err)
 }
 
 func (s *System) FDClose(ctx context.Context, fd wasi.FD) wasi.Errno {
@@ -201,7 +201,7 @@ func (s *System) FDClose(ctx context.Context, fd wasi.FD) wasi.Errno {
 	// See github.com/WebAssembly/wasi-testsuite/blob/1b1d4a5/tests/rust/src/bin/close_preopen.rs
 	s.preopens.Delete(fd)
 	err := unix.Close(f.fd)
-	return MakeErrno(err)
+	return makeErrno(err)
 }
 
 func (s *System) FDDataSync(ctx context.Context, fd wasi.FD) wasi.Errno {
@@ -210,7 +210,7 @@ func (s *System) FDDataSync(ctx context.Context, fd wasi.FD) wasi.Errno {
 		return errno
 	}
 	err := fdatasync(f.fd)
-	return MakeErrno(err)
+	return makeErrno(err)
 }
 
 func (s *System) FDStatGet(ctx context.Context, fd wasi.FD) (wasi.FDStat, wasi.Errno) {
@@ -235,7 +235,7 @@ func (s *System) FDStatSetFlags(ctx context.Context, fd wasi.FD, flags wasi.FDFl
 	}
 	fl, err := unix.FcntlInt(uintptr(f.fd), unix.F_GETFL, 0)
 	if err != nil {
-		return MakeErrno(err)
+		return makeErrno(err)
 	}
 	if flags.Has(wasi.Append) {
 		fl |= unix.O_APPEND
@@ -248,7 +248,7 @@ func (s *System) FDStatSetFlags(ctx context.Context, fd wasi.FD, flags wasi.FDFl
 		fl &^= unix.O_NONBLOCK
 	}
 	if _, err := unix.FcntlInt(uintptr(f.fd), unix.F_SETFL, fl); err != nil {
-		return MakeErrno(err)
+		return makeErrno(err)
 	}
 	f.stat.Flags ^= changes
 	return wasi.ESUCCESS
@@ -280,7 +280,7 @@ func (s *System) FDFileStatGet(ctx context.Context, fd wasi.FD) (wasi.FileStat, 
 	}
 	var sysStat unix.Stat_t
 	if err := unix.Fstat(f.fd, &sysStat); err != nil {
-		return wasi.FileStat{}, MakeErrno(err)
+		return wasi.FileStat{}, makeErrno(err)
 	}
 	stat := makeFileStat(&sysStat)
 	switch f.fd {
@@ -301,7 +301,7 @@ func (s *System) FDFileStatSetSize(ctx context.Context, fd wasi.FD, size wasi.Fi
 		return errno
 	}
 	err := unix.Ftruncate(f.fd, int64(size))
-	return MakeErrno(err)
+	return makeErrno(err)
 }
 
 func (s *System) FDFileStatSetTimes(ctx context.Context, fd wasi.FD, accessTime, modifyTime wasi.Timestamp, flags wasi.FSTFlags) wasi.Errno {
@@ -311,7 +311,7 @@ func (s *System) FDFileStatSetTimes(ctx context.Context, fd wasi.FD, accessTime,
 	}
 	var sysStat unix.Stat_t
 	if err := unix.Fstat(f.fd, &sysStat); err != nil {
-		return MakeErrno(err)
+		return makeErrno(err)
 	}
 	ts := [2]unix.Timespec{sysStat.Atim, sysStat.Mtim}
 	if flags.Has(wasi.AccessTimeNow) || flags.Has(wasi.ModifyTimeNow) {
@@ -320,7 +320,7 @@ func (s *System) FDFileStatSetTimes(ctx context.Context, fd wasi.FD, accessTime,
 		}
 		now, err := s.Monotonic(ctx)
 		if err != nil {
-			return MakeErrno(err)
+			return makeErrno(err)
 		}
 		if flags.Has(wasi.AccessTimeNow) {
 			accessTime = wasi.Timestamp(now)
@@ -336,7 +336,7 @@ func (s *System) FDFileStatSetTimes(ctx context.Context, fd wasi.FD, accessTime,
 		ts[1] = unix.NsecToTimespec(int64(modifyTime))
 	}
 	err := futimens(f.fd, &ts)
-	return MakeErrno(err)
+	return makeErrno(err)
 }
 
 func (s *System) FDPread(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec, offset wasi.FileSize) (wasi.Size, wasi.Errno) {
@@ -345,7 +345,7 @@ func (s *System) FDPread(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec, o
 		return 0, errno
 	}
 	n, err := preadv(f.fd, makeIOVecs(iovecs), int64(offset))
-	return wasi.Size(n), MakeErrno(err)
+	return wasi.Size(n), makeErrno(err)
 }
 
 func (s *System) FDPreStatGet(ctx context.Context, fd wasi.FD) (wasi.PreStat, wasi.Errno) {
@@ -372,7 +372,7 @@ func (s *System) FDPwrite(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec, 
 		return 0, errno
 	}
 	n, err := pwritev(f.fd, makeIOVecs(iovecs), int64(offset))
-	return wasi.Size(n), MakeErrno(err)
+	return wasi.Size(n), makeErrno(err)
 }
 
 func (s *System) FDRead(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec) (wasi.Size, wasi.Errno) {
@@ -381,7 +381,7 @@ func (s *System) FDRead(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec) (w
 		return 0, errno
 	}
 	n, err := readv(f.fd, makeIOVecs(iovecs))
-	return wasi.Size(n), MakeErrno(err)
+	return wasi.Size(n), makeErrno(err)
 }
 
 func (s *System) FDReadDir(ctx context.Context, fd wasi.FD, entries []wasi.DirEntry, cookie wasi.DirCookie, bufferSizeBytes int) (int, wasi.Errno) {
@@ -396,7 +396,7 @@ func (s *System) FDReadDir(ctx context.Context, fd wasi.FD, entries []wasi.DirEn
 		f.dir = new(dirbuf)
 	}
 	n, err := f.dir.readDirEntries(f.fd, entries, cookie, bufferSizeBytes)
-	return n, MakeErrno(err)
+	return n, makeErrno(err)
 }
 
 func (s *System) FDRenumber(ctx context.Context, from, to wasi.FD) wasi.Errno {
@@ -422,7 +422,7 @@ func (s *System) FDSync(ctx context.Context, fd wasi.FD) wasi.Errno {
 		return errno
 	}
 	err := fsync(f.fd)
-	return MakeErrno(err)
+	return makeErrno(err)
 }
 
 func (s *System) FDSeek(ctx context.Context, fd wasi.FD, delta wasi.FileDelta, whence wasi.Whence) (wasi.FileSize, wasi.Errno) {
@@ -453,7 +453,7 @@ func (s *System) fdseek(fd wasi.FD, rights wasi.Rights, delta wasi.FileDelta, wh
 		return 0, wasi.EINVAL
 	}
 	off, err := lseek(f.fd, int64(delta), sysWhence)
-	return wasi.FileSize(off), MakeErrno(err)
+	return wasi.FileSize(off), makeErrno(err)
 }
 
 func (s *System) FDWrite(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec) (wasi.Size, wasi.Errno) {
@@ -462,7 +462,7 @@ func (s *System) FDWrite(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec) (
 		return 0, errno
 	}
 	n, err := writev(f.fd, makeIOVecs(iovecs))
-	return wasi.Size(n), MakeErrno(err)
+	return wasi.Size(n), makeErrno(err)
 }
 
 func (s *System) PathCreateDirectory(ctx context.Context, fd wasi.FD, path string) wasi.Errno {
@@ -471,7 +471,7 @@ func (s *System) PathCreateDirectory(ctx context.Context, fd wasi.FD, path strin
 		return errno
 	}
 	err := unix.Mkdirat(d.fd, path, 0755)
-	return MakeErrno(err)
+	return makeErrno(err)
 }
 
 func (s *System) PathFileStatGet(ctx context.Context, fd wasi.FD, flags wasi.LookupFlags, path string) (wasi.FileStat, wasi.Errno) {
@@ -485,7 +485,7 @@ func (s *System) PathFileStatGet(ctx context.Context, fd wasi.FD, flags wasi.Loo
 		sysFlags |= unix.AT_SYMLINK_NOFOLLOW
 	}
 	err := unix.Fstatat(d.fd, path, &sysStat, sysFlags)
-	return makeFileStat(&sysStat), MakeErrno(err)
+	return makeFileStat(&sysStat), makeErrno(err)
 }
 
 func (s *System) PathFileStatSetTimes(ctx context.Context, fd wasi.FD, lookupFlags wasi.LookupFlags, path string, accessTime, modifyTime wasi.Timestamp, fstFlags wasi.FSTFlags) wasi.Errno {
@@ -513,7 +513,7 @@ func (s *System) PathFileStatSetTimes(ctx context.Context, fd wasi.FD, lookupFla
 		var stat unix.Stat_t
 		err := unix.Fstatat(d.fd, path, &stat, sysFlags)
 		if err != nil {
-			return MakeErrno(err)
+			return makeErrno(err)
 		}
 		ts[0] = stat.Atim
 		ts[1] = stat.Mtim
@@ -525,7 +525,7 @@ func (s *System) PathFileStatSetTimes(ctx context.Context, fd wasi.FD, lookupFla
 		ts[1] = unix.NsecToTimespec(int64(modifyTime))
 	}
 	err := unix.UtimesNanoAt(d.fd, path, ts[:], sysFlags)
-	return MakeErrno(err)
+	return makeErrno(err)
 }
 
 func (s *System) PathLink(ctx context.Context, fd wasi.FD, flags wasi.LookupFlags, oldPath string, newFD wasi.FD, newPath string) wasi.Errno {
@@ -542,7 +542,7 @@ func (s *System) PathLink(ctx context.Context, fd wasi.FD, flags wasi.LookupFlag
 		sysFlags |= unix.AT_SYMLINK_FOLLOW
 	}
 	err := unix.Linkat(oldDir.fd, oldPath, newDir.fd, newPath, sysFlags)
-	return MakeErrno(err)
+	return makeErrno(err)
 }
 
 func (s *System) PathOpen(ctx context.Context, fd wasi.FD, lookupFlags wasi.LookupFlags, path string, openFlags wasi.OpenFlags, rightsBase, rightsInheriting wasi.Rights, fdFlags wasi.FDFlags) (wasi.FD, wasi.Errno) {
@@ -625,7 +625,7 @@ func (s *System) PathOpen(ctx context.Context, fd wasi.FD, lookupFlags wasi.Look
 	}
 	hostfd, err := unix.Openat(d.fd, path, oflags, mode)
 	if err != nil {
-		return -1, MakeErrno(err)
+		return -1, makeErrno(err)
 	}
 
 	guestfd := s.fds.Insert(fdinfo{
@@ -647,7 +647,7 @@ func (s *System) PathReadLink(ctx context.Context, fd wasi.FD, path string, buff
 	}
 	n, err := unix.Readlinkat(d.fd, path, buffer)
 	if err != nil {
-		return buffer, MakeErrno(err)
+		return buffer, makeErrno(err)
 	} else if n == len(buffer) {
 		return buffer, wasi.ERANGE
 	}
@@ -660,7 +660,7 @@ func (s *System) PathRemoveDirectory(ctx context.Context, fd wasi.FD, path strin
 		return errno
 	}
 	err := unix.Unlinkat(d.fd, path, unix.AT_REMOVEDIR)
-	return MakeErrno(err)
+	return makeErrno(err)
 }
 
 func (s *System) PathRename(ctx context.Context, fd wasi.FD, oldPath string, newFD wasi.FD, newPath string) wasi.Errno {
@@ -673,7 +673,7 @@ func (s *System) PathRename(ctx context.Context, fd wasi.FD, oldPath string, new
 		return errno
 	}
 	err := unix.Renameat(oldDir.fd, oldPath, newDir.fd, newPath)
-	return MakeErrno(err)
+	return makeErrno(err)
 }
 
 func (s *System) PathSymlink(ctx context.Context, oldPath string, fd wasi.FD, newPath string) wasi.Errno {
@@ -682,7 +682,7 @@ func (s *System) PathSymlink(ctx context.Context, oldPath string, fd wasi.FD, ne
 		return errno
 	}
 	err := unix.Symlinkat(oldPath, d.fd, newPath)
-	return MakeErrno(err)
+	return makeErrno(err)
 }
 
 func (s *System) PathUnlinkFile(ctx context.Context, fd wasi.FD, path string) wasi.Errno {
@@ -691,7 +691,7 @@ func (s *System) PathUnlinkFile(ctx context.Context, fd wasi.FD, path string) wa
 		return errno
 	}
 	err := unix.Unlinkat(d.fd, path, 0)
-	return MakeErrno(err)
+	return makeErrno(err)
 }
 
 func (s *System) PollOneOff(ctx context.Context, subscriptions []wasi.Subscription, events []wasi.Event) (int, wasi.Errno) {
@@ -700,7 +700,7 @@ func (s *System) PollOneOff(ctx context.Context, subscriptions []wasi.Subscripti
 	}
 	wakefd, err := s.init()
 	if err != nil {
-		return 0, MakeErrno(err)
+		return 0, makeErrno(err)
 	}
 	epoch := time.Duration(0)
 	timeout := time.Duration(-1)
@@ -749,7 +749,7 @@ func (s *System) PollOneOff(ctx context.Context, subscriptions []wasi.Subscripti
 				// monotonic clock configured.
 				now, err := s.Monotonic(ctx)
 				if err != nil {
-					return 0, MakeErrno(err)
+					return 0, makeErrno(err)
 				}
 				epoch = time.Duration(now)
 			}
@@ -783,7 +783,7 @@ func (s *System) PollOneOff(ctx context.Context, subscriptions []wasi.Subscripti
 
 	n, err := unix.Poll(s.pollfds, timeoutMillis)
 	if err != nil {
-		return 0, MakeErrno(err)
+		return 0, makeErrno(err)
 	}
 
 	if n > 0 && s.pollfds[0].Revents != 0 {
@@ -808,7 +808,7 @@ func (s *System) PollOneOff(ctx context.Context, subscriptions []wasi.Subscripti
 	if timeout >= 0 {
 		t, err := s.Monotonic(ctx)
 		if err != nil {
-			return 0, MakeErrno(err)
+			return 0, makeErrno(err)
 		}
 		now = time.Duration(t)
 	}
@@ -889,21 +889,21 @@ func errorEvent(s *wasi.Subscription, err wasi.Errno) wasi.Event {
 
 func (s *System) ProcExit(ctx context.Context, code wasi.ExitCode) wasi.Errno {
 	if s.Exit != nil {
-		return MakeErrno(s.Exit(ctx, int(code)))
+		return makeErrno(s.Exit(ctx, int(code)))
 	}
 	return wasi.ENOSYS
 }
 
 func (s *System) ProcRaise(ctx context.Context, signal wasi.Signal) wasi.Errno {
 	if s.Raise != nil {
-		return MakeErrno(s.Raise(ctx, int(signal)))
+		return makeErrno(s.Raise(ctx, int(signal)))
 	}
 	return wasi.ENOSYS
 }
 
 func (s *System) SchedYield(ctx context.Context) wasi.Errno {
 	if s.Yield != nil {
-		return MakeErrno(s.Yield(ctx))
+		return makeErrno(s.Yield(ctx))
 	}
 	return wasi.ENOSYS
 }
@@ -929,7 +929,7 @@ func (s *System) SockAccept(ctx context.Context, fd wasi.FD, flags wasi.FDFlags)
 	}
 	connfd, _, err := accept(socket.fd, connflags)
 	if err != nil {
-		return -1, MakeErrno(err)
+		return -1, makeErrno(err)
 	}
 	guestfd := s.fds.Insert(fdinfo{
 		fd: connfd,
@@ -978,7 +978,7 @@ func (s *System) SockShutdown(ctx context.Context, fd wasi.FD, flags wasi.SDFlag
 		return wasi.EINVAL
 	}
 	err := unix.Shutdown(socket.fd, sysHow)
-	return MakeErrno(err)
+	return makeErrno(err)
 }
 
 func (s *System) Close(ctx context.Context) error {


### PR DESCRIPTION
Following on from https://github.com/stealthrocket/wasi-go/pull/16, this PR adds the first basic sockets extension, which builds on `path_open` to give WASM modules the ability to create sockets and do arbitrary TCP networking.

<details>
<summary>Here's an example program:</summary>

```console
$ GOOS=wasip1 GOARCH=wasm go build -o path-open-sockets.wasm path-open-sockets.go
$ wasirun --sockets path_open path-open-sockets.wasm &                                                                        
[1] 59291
$ echo foo | nc localhost 8080                                                   
foo
```

```go
package main

import (
	"fmt"
	"log"
	"net"
	"os"
	"unsafe"
)

func main() {
	if err := run(); err != nil {
		log.Fatal(err)
	}
}

func run() error {
	l, err := listen("tcp+listen://localhost:8080")
	if err != nil {
		return err
	}
	defer l.Close()

	for {
		c, err := l.Accept()
		if err != nil {
			panic(err)
		}
		go handleConn(c.(*net.TCPConn))
	}
}

func handleConn(c *net.TCPConn) error {
	var buf [128]byte
	n, err := c.Read(buf[:])
	if err != nil {
		return err
	}
	if _, err := c.Write(buf[:n]); err != nil {
		return err
	}
	if err := c.CloseWrite(); err != nil {
		return err
	}
	return c.Close()
}

func listen(addr string) (net.Listener, error) {
	var fd int32
	errno := path_open(-1, 0, unsafe.Pointer(unsafe.StringData(addr)), int32(len(addr)), 0, ListenRights, ConnectionRights, 0, unsafe.Pointer(&fd))
	if errno != 0 {
		return nil, fmt.Errorf("Errno(%d)", errno)
	}
	return net.FileListener(os.NewFile(uintptr(fd), addr))
}

//go:wasmimport wasi_snapshot_preview1 path_open
//go:noescape
func path_open(rootFD int32, dirflags int32, path unsafe.Pointer, pathLen int32, oflags int32, fsRightsBase, fsRightsInheriting Rights, fsFlags int32, fd unsafe.Pointer) int32

type Rights uint64

const (
	FDDataSyncRight Rights = 1 << iota
	FDReadRight
	FDSeekRight
	FDStatSetFlagsRight
	FDSyncRight
	FDTellRight
	FDWriteRight
	FDAdviseRight
	FDAllocateRight
	PathCreateDirectoryRight
	PathCreateFileRight
	PathLinkSourceRight
	PathLinkTargetRight
	PathOpenRight
	FDReadDirRight
	PathReadLinkRight
	PathRenameSourceRight
	PathRenameTargetRight
	PathFileStatGetRight
	PathFileStatSetSizeRight
	PathFileStatSetTimesRight
	FDFileStatGetRight
	FDFileStatSetSizeRight
	FDFileStatSetTimesRight
	PathSymlinkRight
	PathRemoveDirectoryRight
	PathUnlinkFileRight
	PollFDReadWriteRight
	SockShutdownRight
	SockAcceptRight

	ListenRights     = SockAcceptRight | PollFDReadWriteRight | FDFileStatGetRight | FDStatSetFlagsRight
	ConnectionRights = FDReadRight | FDWriteRight | PollFDReadWriteRight | SockShutdownRight | FDFileStatGetRight | FDStatSetFlagsRight
)
```

</details>