### PR TITLE
wasirun: improve command-line options

### DIFF
--- a/cmd/wasirun/main.go
+++ b/cmd/wasirun/main.go
@@ -88,7 +88,7 @@ func main() {
 	flagSet.Var(&dirs, "dir", "")
 	flagSet.Var(&listens, "listen", "")
 	flagSet.Var(&dials, "dial", "")
-	flagSet.StringVar(&socketExt, "sockets", "", "")
+	flagSet.StringVar(&socketExt, "sockets", "auto", "")
 	flagSet.StringVar(&pprofAddr, "pprof-addr", "", "")
 	flagSet.BoolVar(&trace, "trace", false, "")
 	flagSet.BoolVar(&nonBlockingStdio, "non-blocking-stdio", false, "")


### PR DESCRIPTION
This PR makes the following improvements:
* an invalid flag causes the program to print the same usage as `--help`
* `--version` now prints the actual version
* I renamed `--tcplisten` and `--tcpdial` to their original `--listen` and `--dial`, since they're not limited to TCP sockets, and since there's no need to try to match wasmtime (which supports `--tcplisten`)