### PR TITLE
wasirun: don't grant Seek/Tell rights to stdio

### DIFF
--- a/cmd/wasirun/main.go
+++ b/cmd/wasirun/main.go
@@ -192,9 +192,8 @@ func run(args []string) error {
 		{syscall.Stderr, "/dev/stderr"},
 	} {
 		stat := wasi.FDStat{
-			FileType:         wasi.CharacterDeviceType,
-			RightsBase:       wasi.AllRights,
-			RightsInheriting: wasi.AllRights,
+			FileType:   wasi.CharacterDeviceType,
+			RightsBase: wasi.AllRights & ^(wasi.FDSeekRight | wasi.FDTellRight),
 		}
 		if nonBlockingStdio {
 			if err := syscall.SetNonblock(stdio.fd, true); err != nil {


### PR DESCRIPTION
wasi-libc checks these in its `isatty` implementation: https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/sources/isatty.c#L13-L18

python.wasm from https://github.com/vmware-labs/webassembly-language-runtimes/releases now works:

```
$ wasirun python-3.11.3.wasm  
Python 3.11.3 (tags/v3.11.3:f3909b8, Apr 28 2023, 09:49:53) [Clang 15.0.7 ] on wasi
Type "help", "copyright", "credits" or "license" for more information.
>>> print("Hello, World!")
Hello, World!
```