### PR TITLE
wasi: return SockAccept address

### DIFF
--- a/imports/wasi_snapshot_preview1/module.go
+++ b/imports/wasi_snapshot_preview1/module.go
@@ -474,7 +474,7 @@ func (m *Module) RandomGet(ctx context.Context, buf Bytes) Errno {
 }
 
 func (m *Module) SockAccept(ctx context.Context, fd Int32, flags Int32, connfd Pointer[Int32]) Errno {
-	result, errno := m.WASI.SockAccept(ctx, wasi.FD(fd), wasi.FDFlags(flags))
+	result, _, errno := m.WASI.SockAccept(ctx, wasi.FD(fd), wasi.FDFlags(flags))
 	if errno != wasi.ESUCCESS {
 		return Errno(errno)
 	}

--- a/system.go
+++ b/system.go
@@ -285,8 +285,15 @@ type System interface {
 
 	// SockAccept accepts a new incoming connection.
 	//
+	// Although the method returns the address of the connecting entity, WASI
+	// preview 1 does not currently support passing the address to the calling
+	// WebAssembly module via the "sock_accept" host function call. This
+	// address is only used by implementations and wrappers of the System
+	// interface, and is discarded before returning control to the WebAssembly
+	// module.
+	//
 	// Note: This is similar to accept in POSIX.
-	SockAccept(ctx context.Context, fd FD, flags FDFlags) (FD, Errno)
+	SockAccept(ctx context.Context, fd FD, flags FDFlags) (FD, SocketAddress, Errno)
 
 	// SockRecv receives a message from a socket.
 	//

--- a/tracer.go
+++ b/tracer.go
@@ -550,16 +550,16 @@ func (t *Tracer) RandomGet(ctx context.Context, b []byte) Errno {
 	return errno
 }
 
-func (t *Tracer) SockAccept(ctx context.Context, fd FD, flags FDFlags) (FD, Errno) {
+func (t *Tracer) SockAccept(ctx context.Context, fd FD, flags FDFlags) (FD, SocketAddress, Errno) {
 	t.printf("SockAccept(%d, %s) => ", fd, flags)
-	newfd, errno := t.System.SockAccept(ctx, fd, flags)
+	newfd, addr, errno := t.System.SockAccept(ctx, fd, flags)
 	if errno == ESUCCESS {
-		t.printf("%d", newfd)
+		t.printf("%d, %s", newfd, addr)
 	} else {
 		t.printErrno(errno)
 	}
 	t.printf("\n")
-	return newfd, errno
+	return newfd, addr, errno
 }
 
 func (t *Tracer) SockShutdown(ctx context.Context, fd FD, flags SDFlags) Errno {


### PR DESCRIPTION
The address is used by implementations and wrappers of the `wasi.System` interface only. The information is discarded before returning from the `sock_accept` host function call.

This is useful information to pass around. Just because WASI preview 1 doesn't support returning an address via `sock_accept`, doesn't mean we have to throw away the information so early.