### PR TITLE
export socket pairs when accepting/connecting

### DIFF
--- a/imports/wasi_snapshot_preview1/module.go
+++ b/imports/wasi_snapshot_preview1/module.go
@@ -474,7 +474,7 @@ func (m *Module) RandomGet(ctx context.Context, buf Bytes) Errno {
 }
 
 func (m *Module) SockAccept(ctx context.Context, fd Int32, flags Int32, connfd Pointer[Int32]) Errno {
-	result, _, errno := m.WASI.SockAccept(ctx, wasi.FD(fd), wasi.FDFlags(flags))
+	result, _, _, errno := m.WASI.SockAccept(ctx, wasi.FD(fd), wasi.FDFlags(flags))
 	if errno != wasi.ESUCCESS {
 		return Errno(errno)
 	}

--- a/imports/wasi_snapshot_preview1/wasmedge.go
+++ b/imports/wasi_snapshot_preview1/wasmedge.go
@@ -92,7 +92,8 @@ func (m *Module) WasmEdgeSockConnect(ctx context.Context, fd Int32, addr Pointer
 	if !ok {
 		return Errno(wasi.EINVAL)
 	}
-	return Errno(s.SockConnect(ctx, wasi.FD(fd), socketAddr))
+	_, errno := s.SockConnect(ctx, wasi.FD(fd), socketAddr)
+	return Errno(errno)
 }
 
 func (m *Module) WasmEdgeSockListen(ctx context.Context, fd Int32, backlog Int32) Errno {

--- a/imports/wasi_snapshot_preview1/wasmedge.go
+++ b/imports/wasi_snapshot_preview1/wasmedge.go
@@ -80,7 +80,8 @@ func (m *Module) WasmEdgeSockBind(ctx context.Context, fd Int32, addr Pointer[wa
 	if !ok {
 		return Errno(wasi.EINVAL)
 	}
-	return Errno(s.SockBind(ctx, wasi.FD(fd), socketAddr))
+	_, errno := s.SockBind(ctx, wasi.FD(fd), socketAddr)
+	return Errno(errno)
 }
 
 func (m *Module) WasmEdgeSockConnect(ctx context.Context, fd Int32, addr Pointer[wasmEdgeAddress], port Uint32) Errno {

--- a/imports/wasi_snapshot_preview1/wasmedge.go
+++ b/imports/wasi_snapshot_preview1/wasmedge.go
@@ -239,7 +239,7 @@ func (m *Module) WasmEdgeV1SockPeerAddr(ctx context.Context, fd Int32, addr Poin
 	if !ok {
 		return Errno(wasi.ENOSYS)
 	}
-	sa, errno := s.SockPeerAddress(ctx, wasi.FD(fd))
+	sa, errno := s.SockRemoteAddress(ctx, wasi.FD(fd))
 	if errno != wasi.ESUCCESS {
 		return Errno(errno)
 	}
@@ -257,7 +257,7 @@ func (m *Module) WasmEdgeV2SockPeerAddr(ctx context.Context, fd Int32, addr Poin
 	if !ok {
 		return Errno(wasi.ENOSYS)
 	}
-	sa, errno := s.SockPeerAddress(ctx, wasi.FD(fd))
+	sa, errno := s.SockRemoteAddress(ctx, wasi.FD(fd))
 	if errno != wasi.ESUCCESS {
 		return Errno(errno)
 	}

--- a/sockets_extension.go
+++ b/sockets_extension.go
@@ -17,10 +17,15 @@ type SocketsExtension interface {
 
 	// SockBind binds a socket to an address.
 	//
+	// The method returns the address that the socket has been bound to, which
+	// may differ from the one passed as argument. For example, in cases where
+	// the caller used an address with port 0, and the system is responsible for
+	// selecting a free port to bind the socket to.
+	//
 	// The implementation must not retain the socket address.
 	//
 	// Note: This is similar to bind in POSIX.
-	SockBind(ctx context.Context, fd FD, addr SocketAddress) Errno
+	SockBind(ctx context.Context, fd FD, addr SocketAddress) (SocketAddress, Errno)
 
 	// SockConnect connects a socket to an address, returning the local socket
 	// address that the connection was made from.

--- a/sockets_extension.go
+++ b/sockets_extension.go
@@ -22,12 +22,13 @@ type SocketsExtension interface {
 	// Note: This is similar to bind in POSIX.
 	SockBind(ctx context.Context, fd FD, addr SocketAddress) Errno
 
-	// SockConnect connects a socket to an address.
+	// SockConnect connects a socket to an address, returning the local socket
+	// address that the connection was made from.
 	//
 	// The implementation must not retain the socket address.
 	//
 	// Note: This is similar to connect in POSIX.
-	SockConnect(ctx context.Context, fd FD, addr SocketAddress) Errno
+	SockConnect(ctx context.Context, fd FD, addr SocketAddress) (SocketAddress, Errno)
 
 	// SockListen allows the socket to accept connections with SockAccept.
 	//

--- a/sockets_extension.go
+++ b/sockets_extension.go
@@ -69,14 +69,14 @@ type SocketsExtension interface {
 	// Note: This is similar to getsockname in POSIX.
 	SockLocalAddress(ctx context.Context, fd FD) (SocketAddress, Errno)
 
-	// SockPeerAddress gets the address of the peer when the socket is a
+	// SockRemoteAddress gets the address of the peer when the socket is a
 	// connection.
 	//
 	// The returned address is only valid until the next call on this
 	// interface. Assume that any method may invalidate the address.
 	//
 	// Note: This is similar to getpeername in POSIX.
-	SockPeerAddress(ctx context.Context, fd FD) (SocketAddress, Errno)
+	SockRemoteAddress(ctx context.Context, fd FD) (SocketAddress, Errno)
 }
 
 // Port is a port.

--- a/system.go
+++ b/system.go
@@ -285,6 +285,10 @@ type System interface {
 
 	// SockAccept accepts a new incoming connection.
 	//
+	// The method returns a pair of socket addresses where the first one is the
+	// local server address that accepted the connection, and the second is the
+	// peer address that the connection was established from.
+	//
 	// Although the method returns the address of the connecting entity, WASI
 	// preview 1 does not currently support passing the address to the calling
 	// WebAssembly module via the "sock_accept" host function call. This
@@ -293,7 +297,7 @@ type System interface {
 	// module.
 	//
 	// Note: This is similar to accept in POSIX.
-	SockAccept(ctx context.Context, fd FD, flags FDFlags) (FD, SocketAddress, Errno)
+	SockAccept(ctx context.Context, fd FD, flags FDFlags) (newfd FD, peer, addr SocketAddress, err Errno)
 
 	// SockRecv receives a message from a socket.
 	//

--- a/systems/unix/system.go
+++ b/systems/unix/system.go
@@ -1098,7 +1098,7 @@ func (s *System) SockConnect(ctx context.Context, fd wasi.FD, addr wasi.SocketAd
 	if !ok {
 		return nil, wasi.EINVAL
 	}
-	peer, errno := s.SockPeerAddress(ctx, fd)
+	peer, errno := s.SockRemoteAddress(ctx, fd)
 	if errno != wasi.ESUCCESS {
 		return nil, errno
 	}
@@ -1285,7 +1285,7 @@ func (s *System) SockLocalAddress(ctx context.Context, fd wasi.FD) (wasi.SocketA
 	return addr, wasi.ESUCCESS
 }
 
-func (s *System) SockPeerAddress(ctx context.Context, fd wasi.FD) (wasi.SocketAddress, wasi.Errno) {
+func (s *System) SockRemoteAddress(ctx context.Context, fd wasi.FD) (wasi.SocketAddress, wasi.Errno) {
 	socket, errno := s.lookupSocketFD(fd, 0)
 	if errno != wasi.ESUCCESS {
 		return nil, errno

--- a/tracer.go
+++ b/tracer.go
@@ -620,20 +620,20 @@ func (t *Tracer) SockOpen(ctx context.Context, pf ProtocolFamily, socketType Soc
 	return fd, errno
 }
 
-func (t *Tracer) SockBind(ctx context.Context, fd FD, addr SocketAddress) Errno {
+func (t *Tracer) SockBind(ctx context.Context, fd FD, addr SocketAddress) (SocketAddress, Errno) {
 	s, ok := t.System.(SocketsExtension)
 	if !ok {
-		return ENOSYS
+		return nil, ENOSYS
 	}
 	t.printf("SockBind(%d, %s) => ", fd, addr)
-	errno := s.SockBind(ctx, fd, addr)
+	addr, errno := s.SockBind(ctx, fd, addr)
 	if errno == ESUCCESS {
-		t.printf("ok")
+		t.printf("%s", addr)
 	} else {
 		t.printErrno(errno)
 	}
 	t.printf("\n")
-	return errno
+	return addr, errno
 }
 
 func (t *Tracer) SockConnect(ctx context.Context, fd FD, peer SocketAddress) (SocketAddress, Errno) {

--- a/tracer.go
+++ b/tracer.go
@@ -754,13 +754,13 @@ func (t *Tracer) SockLocalAddress(ctx context.Context, fd FD) (SocketAddress, Er
 	return addr, errno
 }
 
-func (t *Tracer) SockPeerAddress(ctx context.Context, fd FD) (SocketAddress, Errno) {
+func (t *Tracer) SockRemoteAddress(ctx context.Context, fd FD) (SocketAddress, Errno) {
 	s, ok := t.System.(SocketsExtension)
 	if !ok {
 		return nil, ENOSYS
 	}
-	t.printf("SockPeerAddress(%d) => ", fd)
-	addr, errno := s.SockPeerAddress(ctx, fd)
+	t.printf("SockRemoteAddress(%d) => ", fd)
+	addr, errno := s.SockRemoteAddress(ctx, fd)
 	if errno == ESUCCESS {
 		t.printf("%s", addr)
 	} else {

--- a/tracer.go
+++ b/tracer.go
@@ -550,16 +550,16 @@ func (t *Tracer) RandomGet(ctx context.Context, b []byte) Errno {
 	return errno
 }
 
-func (t *Tracer) SockAccept(ctx context.Context, fd FD, flags FDFlags) (FD, SocketAddress, Errno) {
+func (t *Tracer) SockAccept(ctx context.Context, fd FD, flags FDFlags) (FD, SocketAddress, SocketAddress, Errno) {
 	t.printf("SockAccept(%d, %s) => ", fd, flags)
-	newfd, addr, errno := t.System.SockAccept(ctx, fd, flags)
+	newfd, peer, addr, errno := t.System.SockAccept(ctx, fd, flags)
 	if errno == ESUCCESS {
-		t.printf("%d, %s", newfd, addr)
+		t.printf("%d, %s > %s", newfd, peer, addr)
 	} else {
 		t.printErrno(errno)
 	}
 	t.printf("\n")
-	return newfd, addr, errno
+	return newfd, peer, addr, errno
 }
 
 func (t *Tracer) SockShutdown(ctx context.Context, fd FD, flags SDFlags) Errno {
@@ -636,20 +636,20 @@ func (t *Tracer) SockBind(ctx context.Context, fd FD, addr SocketAddress) Errno 
 	return errno
 }
 
-func (t *Tracer) SockConnect(ctx context.Context, fd FD, addr SocketAddress) Errno {
+func (t *Tracer) SockConnect(ctx context.Context, fd FD, peer SocketAddress) (SocketAddress, Errno) {
 	s, ok := t.System.(SocketsExtension)
 	if !ok {
-		return ENOSYS
+		return nil, ENOSYS
 	}
-	t.printf("SockConnect(%d, %s) => ", fd, addr)
-	errno := s.SockConnect(ctx, fd, addr)
+	t.printf("SockConnect(%d, %s) => ", fd, peer)
+	addr, errno := s.SockConnect(ctx, fd, peer)
 	if errno == ESUCCESS {
-		t.printf("ok")
+		t.printf("%s", addr)
 	} else {
 		t.printErrno(errno)
 	}
 	t.printf("\n")
-	return errno
+	return addr, errno
 }
 
 func (t *Tracer) SockListen(ctx context.Context, fd FD, backlog int) Errno {


### PR DESCRIPTION
This change makes it possible to know the pair of local and remote addresses when accepting connections from a pre-open file descriptor, in cases where SockLocalAddress was never called by the guest application. It also results in having all the information needed to construct a `net.Conn` without having to make an extra call.

I also added a second commit to rename `SockPeerAddress` to `SockRemoteAddress`, the correspondence between Local/Remote is more coherent than Local/Peer, which I think we had derived from the WasmEdge ABI. It also reuses the naming of Go's `net` package, making API more familiar to developers.