### PR TITLE
wasi: generic file table

### DIFF
--- a/imports/wasi_snapshot_preview1/module.go
+++ b/imports/wasi_snapshot_preview1/module.go
@@ -409,11 +409,11 @@ func (m *Module) PathOpen(ctx context.Context, fd Int32, dirFlags Int32, path St
 }
 
 func (m *Module) PathReadLink(ctx context.Context, fd Int32, path String, buf Bytes, nwritten Pointer[Int32]) Errno {
-	result, errno := m.WASI.PathReadLink(ctx, wasi.FD(fd), string(path), buf)
+	n, errno := m.WASI.PathReadLink(ctx, wasi.FD(fd), string(path), buf)
 	if errno != wasi.ESUCCESS {
 		return Errno(errno)
 	}
-	nwritten.Store(Int32(len(result)))
+	nwritten.Store(Int32(n))
 	return Errno(wasi.ESUCCESS)
 }
 

--- a/system.go
+++ b/system.go
@@ -4,10 +4,6 @@ import "context"
 
 // System is the WebAssembly System Interface (WASI).
 type System interface {
-	// Preopen registers an open directory or socket as a "preopen", granting
-	// access to the WASM module.
-	Preopen(hostfd int, path string, fdstat FDStat) FD
-
 	// ArgsSizesGet reads command-line argument data sizes.
 	//
 	// The implementation should return the number of args, and the number of
@@ -219,12 +215,13 @@ type System interface {
 
 	// PathReadLink reads the contents of a symbolic link.
 	//
-	// The implementation must read the path into the specified buffer and then
-	// return it. If the buffer is not large enough to hold the contents of the
-	// symbolic link, the implementation must return ERANGE.
+	// The implementation must read the path into the specified buffer and
+	// returns the number of bytes written. If the buffer is not large enough
+	// to hold the contents of the symbolic link, the implementation must
+	// return ERANGE.
 	//
 	// Note: This is similar to readlinkat in POSIX.
-	PathReadLink(ctx context.Context, fd FD, path string, buffer []byte) ([]byte, Errno)
+	PathReadLink(ctx context.Context, fd FD, path string, buffer []byte) (int, Errno)
 
 	// PathRemoveDirectory removes a directory.
 	//
@@ -324,8 +321,4 @@ type System interface {
 
 	// Close closes the System.
 	Close(ctx context.Context) error
-
-	// Register is a lower-level variant of Preopen that registers a file
-	// descriptor.
-	Register(hostfd int, fdstat FDStat) FD
 }

--- a/systems/unix/file.go
+++ b/systems/unix/file.go
@@ -1,0 +1,249 @@
+package unix
+
+import (
+	"context"
+
+	"github.com/stealthrocket/wasi-go"
+	"golang.org/x/sys/unix"
+)
+
+type FD int
+
+func (fd FD) FDAdvise(ctx context.Context, offset, length wasi.FileSize, advice wasi.Advice) wasi.Errno {
+	err := fdadvise(int(fd), int64(offset), int64(length), advice)
+	return makeErrno(err)
+}
+
+func (fd FD) FDAllocate(ctx context.Context, offset, length wasi.FileSize) wasi.Errno {
+	err := fallocate(int(fd), int64(offset), int64(length))
+	return makeErrno(err)
+}
+
+func (fd FD) FDClose(ctx context.Context) wasi.Errno {
+	err := unix.Close(int(fd))
+	return makeErrno(err)
+}
+
+func (fd FD) FDDataSync(ctx context.Context) wasi.Errno {
+	err := fdatasync(int(fd))
+	return makeErrno(err)
+}
+
+func (fd FD) FDStatSetFlags(ctx context.Context, flags wasi.FDFlags) wasi.Errno {
+	fl, err := unix.FcntlInt(uintptr(fd), unix.F_GETFL, 0)
+	if err != nil {
+		return makeErrno(err)
+	}
+	if flags.Has(wasi.Append) {
+		fl |= unix.O_APPEND
+	} else {
+		fl &^= unix.O_APPEND
+	}
+	if flags.Has(wasi.NonBlock) {
+		fl |= unix.O_NONBLOCK
+	} else {
+		fl &^= unix.O_NONBLOCK
+	}
+	_, err = unix.FcntlInt(uintptr(fd), unix.F_SETFL, fl)
+	return makeErrno(err)
+}
+
+func (fd FD) FDFileStatGet(ctx context.Context) (wasi.FileStat, wasi.Errno) {
+	var sysStat unix.Stat_t
+	if err := unix.Fstat(int(fd), &sysStat); err != nil {
+		return wasi.FileStat{}, makeErrno(err)
+	}
+	stat := makeFileStat(&sysStat)
+	return stat, wasi.ESUCCESS
+}
+
+func (fd FD) FDFileStatSetSize(ctx context.Context, size wasi.FileSize) wasi.Errno {
+	err := unix.Ftruncate(int(fd), int64(size))
+	return makeErrno(err)
+}
+
+func (fd FD) FDFileStatSetTimes(ctx context.Context, accessTime, modifyTime wasi.Timestamp) wasi.Errno {
+	err := futimens(int(fd), &[2]unix.Timespec{
+		0: unix.NsecToTimespec(int64(accessTime)),
+		1: unix.NsecToTimespec(int64(modifyTime)),
+	})
+	return makeErrno(err)
+}
+
+func (fd FD) FDPread(ctx context.Context, iovecs []wasi.IOVec, offset wasi.FileSize) (wasi.Size, wasi.Errno) {
+	n, err := preadv(int(fd), makeIOVecs(iovecs), int64(offset))
+	return wasi.Size(n), makeErrno(err)
+}
+
+func (fd FD) FDPwrite(ctx context.Context, iovecs []wasi.IOVec, offset wasi.FileSize) (wasi.Size, wasi.Errno) {
+	n, err := pwritev(int(fd), makeIOVecs(iovecs), int64(offset))
+	return wasi.Size(n), makeErrno(err)
+}
+
+func (fd FD) FDRead(ctx context.Context, iovecs []wasi.IOVec) (wasi.Size, wasi.Errno) {
+	n, err := readv(int(fd), makeIOVecs(iovecs))
+	return wasi.Size(n), makeErrno(err)
+}
+
+func (fd FD) FDWrite(ctx context.Context, iovecs []wasi.IOVec) (wasi.Size, wasi.Errno) {
+	n, err := writev(int(fd), makeIOVecs(iovecs))
+	return wasi.Size(n), makeErrno(err)
+}
+
+func (fd FD) FDOpenDir(ctx context.Context) (wasi.Dir, wasi.Errno) {
+	return &dirbuf{fd: int(fd)}, wasi.ESUCCESS
+}
+
+func (fd FD) FDSync(ctx context.Context) wasi.Errno {
+	err := fsync(int(fd))
+	return makeErrno(err)
+}
+
+func (fd FD) FDSeek(ctx context.Context, delta wasi.FileDelta, whence wasi.Whence) (wasi.FileSize, wasi.Errno) {
+	var sysWhence int
+	switch whence {
+	case wasi.SeekStart:
+		sysWhence = unix.SEEK_SET
+	case wasi.SeekCurrent:
+		sysWhence = unix.SEEK_CUR
+	case wasi.SeekEnd:
+		sysWhence = unix.SEEK_END
+	default:
+		return 0, wasi.EINVAL
+	}
+	off, err := lseek(int(fd), int64(delta), sysWhence)
+	return wasi.FileSize(off), makeErrno(err)
+}
+
+func (fd FD) PathCreateDirectory(ctx context.Context, path string) wasi.Errno {
+	err := unix.Mkdirat(int(fd), path, 0755)
+	return makeErrno(err)
+}
+
+func (fd FD) PathFileStatGet(ctx context.Context, flags wasi.LookupFlags, path string) (wasi.FileStat, wasi.Errno) {
+	var sysStat unix.Stat_t
+	var sysFlags int
+	if !flags.Has(wasi.SymlinkFollow) {
+		sysFlags |= unix.AT_SYMLINK_NOFOLLOW
+	}
+	err := unix.Fstatat(int(fd), path, &sysStat, sysFlags)
+	return makeFileStat(&sysStat), makeErrno(err)
+}
+
+func (fd FD) PathFileStatSetTimes(ctx context.Context, lookupFlags wasi.LookupFlags, path string, accessTime, modifyTime wasi.Timestamp) wasi.Errno {
+	var sysFlags int
+	if !lookupFlags.Has(wasi.SymlinkFollow) {
+		sysFlags |= unix.AT_SYMLINK_NOFOLLOW
+	}
+	ts := [2]unix.Timespec{
+		0: unix.NsecToTimespec(int64(accessTime)),
+		1: unix.NsecToTimespec(int64(modifyTime)),
+	}
+	err := unix.UtimesNanoAt(int(fd), path, ts[:], sysFlags)
+	return makeErrno(err)
+}
+
+func (fd FD) PathLink(ctx context.Context, flags wasi.LookupFlags, oldPath string, newDir FD, newPath string) wasi.Errno {
+	var sysFlags int
+	if flags.Has(wasi.SymlinkFollow) {
+		sysFlags |= unix.AT_SYMLINK_FOLLOW
+	}
+	err := unix.Linkat(int(fd), oldPath, int(newDir), newPath, sysFlags)
+	return makeErrno(err)
+}
+
+func (fd FD) PathOpen(ctx context.Context, lookupFlags wasi.LookupFlags, path string, openFlags wasi.OpenFlags, rightsBase, rightsInheriting wasi.Rights, fdFlags wasi.FDFlags) (FD, wasi.Errno) {
+	oflags := unix.O_CLOEXEC
+	if openFlags.Has(wasi.OpenDirectory) {
+		oflags |= unix.O_DIRECTORY
+		rightsBase &= wasi.DirectoryRights
+	}
+	if openFlags.Has(wasi.OpenCreate) {
+		oflags |= unix.O_CREAT
+	}
+	if openFlags.Has(wasi.OpenExclusive) {
+		oflags |= unix.O_EXCL
+	}
+	if openFlags.Has(wasi.OpenTruncate) {
+		oflags |= unix.O_TRUNC
+	}
+	if fdFlags.Has(wasi.Append) {
+		oflags |= unix.O_APPEND
+	}
+	if fdFlags.Has(wasi.DSync) {
+		oflags |= unix.O_DSYNC
+	}
+	if fdFlags.Has(wasi.Sync) {
+		oflags |= unix.O_SYNC
+	}
+	if fdFlags.Has(wasi.RSync) {
+		// O_RSYNC is not widely supported, and in many cases is an
+		// alias for O_SYNC.
+		oflags |= unix.O_SYNC
+	}
+	if fdFlags.Has(wasi.NonBlock) {
+		oflags |= unix.O_NONBLOCK
+	}
+	if !lookupFlags.Has(wasi.SymlinkFollow) {
+		oflags |= unix.O_NOFOLLOW
+	}
+	switch {
+	case openFlags.Has(wasi.OpenDirectory):
+		oflags |= unix.O_RDONLY
+	case rightsBase.HasAny(wasi.ReadRights) && rightsBase.HasAny(wasi.WriteRights):
+		oflags |= unix.O_RDWR
+	case rightsBase.HasAny(wasi.ReadRights):
+		oflags |= unix.O_RDONLY
+	case rightsBase.HasAny(wasi.WriteRights):
+		oflags |= unix.O_WRONLY
+	default:
+		oflags |= unix.O_RDONLY
+	}
+
+	mode := uint32(0644)
+	if (oflags & unix.O_DIRECTORY) != 0 {
+		mode = 0
+	}
+	hostfd, err := unix.Openat(int(fd), path, oflags, mode)
+	return FD(hostfd), makeErrno(err)
+}
+
+func (fd FD) PathReadLink(ctx context.Context, path string, buffer []byte) (int, wasi.Errno) {
+	n, err := unix.Readlinkat(int(fd), path, buffer)
+	if err != nil {
+		return n, makeErrno(err)
+	} else if n == len(buffer) {
+		return n, wasi.ERANGE
+	} else {
+		return n, wasi.ESUCCESS
+	}
+}
+
+func (fd FD) PathRemoveDirectory(ctx context.Context, path string) wasi.Errno {
+	err := unix.Unlinkat(int(fd), path, unix.AT_REMOVEDIR)
+	return makeErrno(err)
+}
+
+func (fd FD) PathRename(ctx context.Context, oldPath string, newDir FD, newPath string) wasi.Errno {
+	err := unix.Renameat(int(fd), oldPath, int(newDir), newPath)
+	return makeErrno(err)
+}
+
+func (fd FD) PathSymlink(ctx context.Context, oldPath string, newPath string) wasi.Errno {
+	err := unix.Symlinkat(oldPath, int(fd), newPath)
+	return makeErrno(err)
+}
+
+func (fd FD) PathUnlinkFile(ctx context.Context, path string) wasi.Errno {
+	err := unix.Unlinkat(int(fd), path, 0)
+	return makeErrno(err)
+}
+
+func (d *dirbuf) FDReadDir(ctx context.Context, entries []wasi.DirEntry, cookie wasi.DirCookie, bufferSizeBytes int) (int, wasi.Errno) {
+	n, err := d.readDirEntries(entries, cookie, bufferSizeBytes)
+	return n, makeErrno(err)
+}
+
+func (d *dirbuf) FDCloseDir(ctx context.Context) wasi.Errno {
+	return wasi.ESUCCESS
+}

--- a/systems/unix/path_open_sockets.go
+++ b/systems/unix/path_open_sockets.go
@@ -26,7 +26,7 @@ import (
 // - nodelay=<0|1>:   Set TCP_NODELAY. Default is 1.
 // - reuseaddr=<0|1>: Set SO_REUSEADDR. Default is 1.
 // - backlog=<N>:     Set the listen(2) backlog. Default is 128.
-type PathOpenSockets struct{ wasi.System }
+type PathOpenSockets struct{ *System }
 
 func (p *PathOpenSockets) PathOpen(ctx context.Context, fd wasi.FD, lookupFlags wasi.LookupFlags, path string, openFlags wasi.OpenFlags, rightsBase, rightsInheriting wasi.Rights, fdFlags wasi.FDFlags) (wasi.FD, wasi.Errno) {
 	addr, op, ok := parseURI(path)
@@ -48,7 +48,7 @@ func (p *PathOpenSockets) PathOpen(ctx context.Context, fd wasi.FD, lookupFlags 
 			return -1, errno
 		}
 	}
-	return p.Register(sockfd, wasi.FDStat{
+	return p.Register(FD(sockfd), wasi.FDStat{
 		FileType:         wasi.SocketStreamType,
 		Flags:            fdFlags,
 		RightsBase:       rightsBase,

--- a/systems/unix/readdir_darwin.go
+++ b/systems/unix/readdir_darwin.go
@@ -24,17 +24,18 @@ type dirbuf struct {
 	buffer *[bufferSize]byte
 	offset int
 	length int
+	fd     int
 	cookie wasi.DirCookie
 	basep  uintptr
 }
 
-func (d *dirbuf) readDirEntries(fd int, entries []wasi.DirEntry, cookie wasi.DirCookie, bufferSizeBytes int) (int, error) {
+func (d *dirbuf) readDirEntries(entries []wasi.DirEntry, cookie wasi.DirCookie, bufferSizeBytes int) (int, error) {
 	if d.buffer == nil {
 		d.buffer = new([bufferSize]byte)
 	}
 
 	if cookie < d.cookie {
-		if _, err := syscall.Seek(fd, 0, 0); err != nil {
+		if _, err := syscall.Seek(d.fd, 0, 0); err != nil {
 			return 0, err
 		}
 		d.offset = 0
@@ -53,7 +54,7 @@ func (d *dirbuf) readDirEntries(fd int, entries []wasi.DirEntry, cookie wasi.Dir
 			if numEntries > 0 {
 				return numEntries, nil
 			}
-			n, err := syscall.Getdirentries(fd, d.buffer[:], &d.basep)
+			n, err := syscall.Getdirentries(d.fd, d.buffer[:], &d.basep)
 			if err != nil {
 				return numEntries, err
 			}

--- a/systems/unix/readdir_linux.go
+++ b/systems/unix/readdir_linux.go
@@ -24,16 +24,17 @@ type dirbuf struct {
 	buffer *[bufferSize]byte
 	offset int
 	length int
+	fd     int
 	cookie wasi.DirCookie
 }
 
-func (d *dirbuf) readDirEntries(fd int, entries []wasi.DirEntry, cookie wasi.DirCookie, bufferSizeBytes int) (int, error) {
+func (d *dirbuf) readDirEntries(entries []wasi.DirEntry, cookie wasi.DirCookie, bufferSizeBytes int) (int, error) {
 	if d.buffer == nil {
 		d.buffer = new([bufferSize]byte)
 	}
 
 	if cookie < d.cookie {
-		if _, err := unix.Seek(fd, 0, unix.SEEK_SET); err != nil {
+		if _, err := unix.Seek(d.fd, 0, unix.SEEK_SET); err != nil {
 			return 0, err
 		}
 		d.offset = 0
@@ -51,7 +52,7 @@ func (d *dirbuf) readDirEntries(fd int, entries []wasi.DirEntry, cookie wasi.Dir
 			if numEntries > 0 {
 				return numEntries, nil
 			}
-			n, err := unix.Getdents(fd, d.buffer[:])
+			n, err := unix.Getdents(d.fd, d.buffer[:])
 			if err != nil {
 				return numEntries, err
 			}

--- a/systems/unix/syscall_linux.go
+++ b/systems/unix/syscall_linux.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	__UTIME_NOW  = unix.UTIME_NOW
-	__UTIME_OMIT = unix.UTIME_OMMIT
+	__UTIME_OMIT = unix.UTIME_OMIT
 )
 
 func accept(socket, flags int) (int, unix.Sockaddr, error) {

--- a/systems/unix/syscall_linux.go
+++ b/systems/unix/syscall_linux.go
@@ -8,6 +8,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const (
+	__UTIME_NOW  = unix.UTIME_NOW
+	__UTIME_OMIT = unix.UTIME_OMMIT
+)
+
 func accept(socket, flags int) (int, unix.Sockaddr, error) {
 	return unix.Accept4(socket, flags|unix.O_CLOEXEC)
 }

--- a/systems/unix/system.go
+++ b/systems/unix/system.go
@@ -3,13 +3,10 @@ package unix
 import (
 	"context"
 	"io"
-	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/stealthrocket/wasi-go"
-	"github.com/stealthrocket/wasi-go/internal/descriptor"
 	"golang.org/x/sys/unix"
 )
 
@@ -48,8 +45,7 @@ type System struct {
 	// Rand is the source for RandomGet.
 	Rand io.Reader
 
-	fds      descriptor.Table[wasi.FD, fdinfo]
-	preopens descriptor.Table[wasi.FD, string]
+	wasi.FileTable[FD]
 
 	pollfds   []unix.PollFd
 	unixInet4 unix.SockaddrInet4
@@ -73,83 +69,9 @@ type System struct {
 var _ wasi.System = (*System)(nil)
 var _ wasi.SocketsExtension = (*System)(nil)
 
-type fdinfo struct {
-	// fd is the underlying OS file descriptor.
-	fd int
-
-	// stat is cached information about the file descriptor.
-	stat wasi.FDStat
-
-	// dir is lazily allocated when FDReadDir is called, it maintains the state
-	// of the directory iterator.
-	dir *dirbuf
-}
-
-// Preopen adds an open file to the list of pre-opens.
-func (s *System) Preopen(hostfd int, path string, fdstat wasi.FDStat) wasi.FD {
-	fd := s.Register(hostfd, fdstat)
-	s.preopens.Assign(fd, path)
-	return fd
-}
-
-func (s *System) Register(hostfd int, fdstat wasi.FDStat) wasi.FD {
-	fdstat.RightsBase &= wasi.AllRights
-	fdstat.RightsInheriting &= wasi.AllRights
-	return s.fds.Insert(fdinfo{
-		fd:   hostfd,
-		stat: fdstat,
-	})
-}
-
-func (s *System) isPreopen(fd wasi.FD) bool {
-	return s.preopens.Access(fd) != nil
-}
-
-func (s *System) lookupFD(guestfd wasi.FD, rights wasi.Rights) (*fdinfo, wasi.Errno) {
-	f := s.fds.Access(guestfd)
-	if f == nil {
-		return nil, wasi.EBADF
-	}
-	if !f.stat.RightsBase.Has(rights) {
-		return nil, wasi.ENOTCAPABLE
-	}
-	return f, wasi.ESUCCESS
-}
-
-func (s *System) lookupPreopenPath(guestfd wasi.FD) (string, wasi.Errno) {
-	path, ok := s.preopens.Lookup(guestfd)
-	if !ok {
-		return "", wasi.EBADF
-	}
-	f, errno := s.lookupFD(guestfd, 0)
-	if errno != wasi.ESUCCESS {
-		return "", errno
-	}
-	if f.stat.FileType != wasi.DirectoryType {
-		return "", wasi.ENOTDIR
-	}
-	return path, wasi.ESUCCESS
-}
-
-func (s *System) lookupSocketFD(guestfd wasi.FD, rights wasi.Rights) (*fdinfo, wasi.Errno) {
-	f, errno := s.lookupFD(guestfd, rights)
-	if errno != wasi.ESUCCESS {
-		return nil, errno
-	}
-	switch f.stat.FileType {
-	case wasi.SocketStreamType, wasi.SocketDGramType:
-		return f, wasi.ESUCCESS
-	default:
-		return nil, wasi.ENOTSOCK
-	}
-}
-
 func (s *System) ArgsSizesGet(ctx context.Context) (argCount, stringBytes int, errno wasi.Errno) {
-	argCount = len(s.Args)
-	for _, arg := range s.Args {
-		stringBytes += len(arg) + 1
-	}
-	return argCount, stringBytes, wasi.ESUCCESS
+	argCount, stringBytes = wasi.SizesGet(s.Args)
+	return
 }
 
 func (s *System) ArgsGet(ctx context.Context) ([]string, wasi.Errno) {
@@ -157,11 +79,8 @@ func (s *System) ArgsGet(ctx context.Context) ([]string, wasi.Errno) {
 }
 
 func (s *System) EnvironSizesGet(ctx context.Context) (envCount, stringBytes int, errno wasi.Errno) {
-	envCount = len(s.Environ)
-	for _, env := range s.Environ {
-		stringBytes += len(env) + 1
-	}
-	return envCount, stringBytes, wasi.ESUCCESS
+	envCount, stringBytes = wasi.SizesGet(s.Environ)
+	return
 }
 
 func (s *System) EnvironGet(ctx context.Context) ([]string, wasi.Errno) {
@@ -202,528 +121,6 @@ func (s *System) ClockTimeGet(ctx context.Context, id wasi.ClockID, precision wa
 	}
 }
 
-func (s *System) FDAdvise(ctx context.Context, fd wasi.FD, offset wasi.FileSize, length wasi.FileSize, advice wasi.Advice) wasi.Errno {
-	f, errno := s.lookupFD(fd, wasi.FDAdviseRight)
-	if errno != wasi.ESUCCESS {
-		return errno
-	}
-	err := fdadvise(f.fd, int64(offset), int64(length), advice)
-	return makeErrno(err)
-}
-
-func (s *System) FDAllocate(ctx context.Context, fd wasi.FD, offset wasi.FileSize, length wasi.FileSize) wasi.Errno {
-	f, errno := s.lookupFD(fd, wasi.FDAllocateRight)
-	if errno != wasi.ESUCCESS {
-		return errno
-	}
-	err := fallocate(f.fd, int64(offset), int64(length))
-	return makeErrno(err)
-}
-
-func (s *System) FDClose(ctx context.Context, fd wasi.FD) wasi.Errno {
-	f, errno := s.lookupFD(fd, 0)
-	if errno != wasi.ESUCCESS {
-		return errno
-	}
-	err := unix.Close(f.fd)
-	s.fds.Delete(fd)
-	// Note: closing pre-opens is allowed.
-	// See github.com/WebAssembly/wasi-testsuite/blob/1b1d4a5/tests/rust/src/bin/close_preopen.rs
-	s.preopens.Delete(fd)
-	return makeErrno(err)
-}
-
-func (s *System) FDDataSync(ctx context.Context, fd wasi.FD) wasi.Errno {
-	f, errno := s.lookupFD(fd, wasi.FDDataSyncRight)
-	if errno != wasi.ESUCCESS {
-		return errno
-	}
-	err := fdatasync(f.fd)
-	return makeErrno(err)
-}
-
-func (s *System) FDStatGet(ctx context.Context, fd wasi.FD) (wasi.FDStat, wasi.Errno) {
-	f, errno := s.lookupFD(fd, 0)
-	if errno != wasi.ESUCCESS {
-		return wasi.FDStat{}, errno
-	}
-	return f.stat, wasi.ESUCCESS
-}
-
-func (s *System) FDStatSetFlags(ctx context.Context, fd wasi.FD, flags wasi.FDFlags) wasi.Errno {
-	f, errno := s.lookupFD(fd, wasi.FDStatSetFlagsRight)
-	if errno != wasi.ESUCCESS {
-		return errno
-	}
-	changes := flags ^ f.stat.Flags
-	if changes == 0 {
-		return wasi.ESUCCESS
-	}
-	if changes.Has(wasi.Sync | wasi.DSync | wasi.RSync) {
-		return wasi.ENOSYS // TODO: support changing {Sync,DSync,Rsync}
-	}
-	fl, err := unix.FcntlInt(uintptr(f.fd), unix.F_GETFL, 0)
-	if err != nil {
-		return makeErrno(err)
-	}
-	if flags.Has(wasi.Append) {
-		fl |= unix.O_APPEND
-	} else {
-		fl &^= unix.O_APPEND
-	}
-	if flags.Has(wasi.NonBlock) {
-		fl |= unix.O_NONBLOCK
-	} else {
-		fl &^= unix.O_NONBLOCK
-	}
-	if _, err := unix.FcntlInt(uintptr(f.fd), unix.F_SETFL, fl); err != nil {
-		return makeErrno(err)
-	}
-	f.stat.Flags ^= changes
-	return wasi.ESUCCESS
-}
-
-func (s *System) FDStatSetRights(ctx context.Context, fd wasi.FD, rightsBase, rightsInheriting wasi.Rights) wasi.Errno {
-	f, errno := s.lookupFD(fd, 0)
-	if errno != wasi.ESUCCESS {
-		return errno
-	}
-	// Rights can only be preserved or removed, not added.
-	rightsBase &= wasi.AllRights
-	rightsInheriting &= wasi.AllRights
-	if (rightsBase &^ f.stat.RightsBase) != 0 {
-		return wasi.ENOTCAPABLE
-	}
-	if (rightsInheriting &^ f.stat.RightsInheriting) != 0 {
-		return wasi.ENOTCAPABLE
-	}
-	f.stat.RightsBase &= rightsBase
-	f.stat.RightsInheriting &= rightsInheriting
-	return wasi.ESUCCESS
-}
-
-func (s *System) FDFileStatGet(ctx context.Context, fd wasi.FD) (wasi.FileStat, wasi.Errno) {
-	f, errno := s.lookupFD(fd, wasi.FDFileStatGetRight)
-	if errno != wasi.ESUCCESS {
-		return wasi.FileStat{}, errno
-	}
-	var sysStat unix.Stat_t
-	if err := unix.Fstat(f.fd, &sysStat); err != nil {
-		return wasi.FileStat{}, makeErrno(err)
-	}
-	stat := makeFileStat(&sysStat)
-	if fd <= 2 {
-		// Override stdio size/times.
-		// See github.com/WebAssembly/wasi-testsuite/blob/1b1d4a5/tests/rust/src/bin/fd_filestat_get.rs
-		stat.Size = 0
-		stat.AccessTime = 0
-		stat.ModifyTime = 0
-		stat.ChangeTime = 0
-	}
-	return stat, wasi.ESUCCESS
-}
-
-func (s *System) FDFileStatSetSize(ctx context.Context, fd wasi.FD, size wasi.FileSize) wasi.Errno {
-	f, errno := s.lookupFD(fd, wasi.FDFileStatSetSizeRight)
-	if errno != wasi.ESUCCESS {
-		return errno
-	}
-	err := unix.Ftruncate(f.fd, int64(size))
-	return makeErrno(err)
-}
-
-func (s *System) FDFileStatSetTimes(ctx context.Context, fd wasi.FD, accessTime, modifyTime wasi.Timestamp, flags wasi.FSTFlags) wasi.Errno {
-	f, errno := s.lookupFD(fd, wasi.FDFileStatSetTimesRight)
-	if errno != wasi.ESUCCESS {
-		return errno
-	}
-	var sysStat unix.Stat_t
-	if err := unix.Fstat(f.fd, &sysStat); err != nil {
-		return makeErrno(err)
-	}
-	ts := [2]unix.Timespec{sysStat.Atim, sysStat.Mtim}
-	if flags.Has(wasi.AccessTimeNow) || flags.Has(wasi.ModifyTimeNow) {
-		if s.Monotonic == nil {
-			return wasi.ENOSYS
-		}
-		now, err := s.Monotonic(ctx)
-		if err != nil {
-			return makeErrno(err)
-		}
-		if flags.Has(wasi.AccessTimeNow) {
-			accessTime = wasi.Timestamp(now)
-		}
-		if flags.Has(wasi.ModifyTimeNow) {
-			modifyTime = wasi.Timestamp(now)
-		}
-	}
-	if flags.Has(wasi.AccessTime) || flags.Has(wasi.AccessTimeNow) {
-		ts[0] = unix.NsecToTimespec(int64(accessTime))
-	}
-	if flags.Has(wasi.ModifyTime) || flags.Has(wasi.ModifyTimeNow) {
-		ts[1] = unix.NsecToTimespec(int64(modifyTime))
-	}
-	err := futimens(f.fd, &ts)
-	return makeErrno(err)
-}
-
-func (s *System) FDPread(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec, offset wasi.FileSize) (wasi.Size, wasi.Errno) {
-	f, errno := s.lookupFD(fd, wasi.FDReadRight|wasi.FDSeekRight)
-	if errno != wasi.ESUCCESS {
-		return 0, errno
-	}
-	n, err := preadv(f.fd, makeIOVecs(iovecs), int64(offset))
-	return wasi.Size(n), makeErrno(err)
-}
-
-func (s *System) FDPreStatGet(ctx context.Context, fd wasi.FD) (wasi.PreStat, wasi.Errno) {
-	path, errno := s.lookupPreopenPath(fd)
-	if errno != wasi.ESUCCESS {
-		return wasi.PreStat{}, errno
-	}
-	stat := wasi.PreStat{
-		Type: wasi.PreOpenDir,
-		PreStatDir: wasi.PreStatDir{
-			NameLength: wasi.Size(len(path)),
-		},
-	}
-	return stat, wasi.ESUCCESS
-}
-
-func (s *System) FDPreStatDirName(ctx context.Context, fd wasi.FD) (string, wasi.Errno) {
-	return s.lookupPreopenPath(fd)
-}
-
-func (s *System) FDPwrite(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec, offset wasi.FileSize) (wasi.Size, wasi.Errno) {
-	f, errno := s.lookupFD(fd, wasi.FDWriteRight|wasi.FDSeekRight)
-	if errno != wasi.ESUCCESS {
-		return 0, errno
-	}
-	n, err := pwritev(f.fd, makeIOVecs(iovecs), int64(offset))
-	return wasi.Size(n), makeErrno(err)
-}
-
-func (s *System) FDRead(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec) (wasi.Size, wasi.Errno) {
-	f, errno := s.lookupFD(fd, wasi.FDReadRight)
-	if errno != wasi.ESUCCESS {
-		return 0, errno
-	}
-	n, err := readv(f.fd, makeIOVecs(iovecs))
-	return wasi.Size(n), makeErrno(err)
-}
-
-func (s *System) FDReadDir(ctx context.Context, fd wasi.FD, entries []wasi.DirEntry, cookie wasi.DirCookie, bufferSizeBytes int) (int, wasi.Errno) {
-	f, errno := s.lookupFD(fd, wasi.FDReadDirRight)
-	if errno != wasi.ESUCCESS {
-		return 0, errno
-	}
-	if len(entries) == 0 {
-		return 0, wasi.EINVAL
-	}
-	if f.dir == nil {
-		f.dir = new(dirbuf)
-	}
-	n, err := f.dir.readDirEntries(f.fd, entries, cookie, bufferSizeBytes)
-	return n, makeErrno(err)
-}
-
-func (s *System) FDRenumber(ctx context.Context, from, to wasi.FD) wasi.Errno {
-	if s.isPreopen(from) || s.isPreopen(to) {
-		return wasi.ENOTSUP
-	}
-	f, errno := s.lookupFD(from, 0)
-	if errno != wasi.ESUCCESS {
-		return errno
-	}
-	// TODO: limit max file descriptor number
-	g, replaced := s.fds.Assign(to, *f)
-	if replaced {
-		unix.Close(g.fd)
-	}
-	s.fds.Delete(from)
-	return wasi.ESUCCESS
-}
-
-func (s *System) FDSync(ctx context.Context, fd wasi.FD) wasi.Errno {
-	f, errno := s.lookupFD(fd, wasi.FDSyncRight)
-	if errno != wasi.ESUCCESS {
-		return errno
-	}
-	err := fsync(f.fd)
-	return makeErrno(err)
-}
-
-func (s *System) FDSeek(ctx context.Context, fd wasi.FD, delta wasi.FileDelta, whence wasi.Whence) (wasi.FileSize, wasi.Errno) {
-	return s.fdseek(fd, wasi.FDSeekRight, delta, whence)
-}
-
-func (s *System) FDTell(ctx context.Context, fd wasi.FD) (wasi.FileSize, wasi.Errno) {
-	return s.fdseek(fd, wasi.FDTellRight, 0, wasi.SeekCurrent)
-}
-
-func (s *System) fdseek(fd wasi.FD, rights wasi.Rights, delta wasi.FileDelta, whence wasi.Whence) (wasi.FileSize, wasi.Errno) {
-	// Note: FDSeekRight implies FDTellRight. FDTellRight also includes the
-	// right to invoke FDSeek in such a way that the file offset remains
-	// unaltered.
-	f, errno := s.lookupFD(fd, rights)
-	if errno != wasi.ESUCCESS {
-		return 0, errno
-	}
-	var sysWhence int
-	switch whence {
-	case wasi.SeekStart:
-		sysWhence = unix.SEEK_SET
-	case wasi.SeekCurrent:
-		sysWhence = unix.SEEK_CUR
-	case wasi.SeekEnd:
-		sysWhence = unix.SEEK_END
-	default:
-		return 0, wasi.EINVAL
-	}
-	off, err := lseek(f.fd, int64(delta), sysWhence)
-	return wasi.FileSize(off), makeErrno(err)
-}
-
-func (s *System) FDWrite(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec) (wasi.Size, wasi.Errno) {
-	f, errno := s.lookupFD(fd, wasi.FDWriteRight)
-	if errno != wasi.ESUCCESS {
-		return 0, errno
-	}
-	n, err := writev(f.fd, makeIOVecs(iovecs))
-	return wasi.Size(n), makeErrno(err)
-}
-
-func (s *System) PathCreateDirectory(ctx context.Context, fd wasi.FD, path string) wasi.Errno {
-	d, errno := s.lookupFD(fd, wasi.PathCreateDirectoryRight)
-	if errno != wasi.ESUCCESS {
-		return errno
-	}
-	err := unix.Mkdirat(d.fd, path, 0755)
-	return makeErrno(err)
-}
-
-func (s *System) PathFileStatGet(ctx context.Context, fd wasi.FD, flags wasi.LookupFlags, path string) (wasi.FileStat, wasi.Errno) {
-	d, errno := s.lookupFD(fd, wasi.PathFileStatGetRight)
-	if errno != wasi.ESUCCESS {
-		return wasi.FileStat{}, errno
-	}
-	var sysStat unix.Stat_t
-	var sysFlags int
-	if !flags.Has(wasi.SymlinkFollow) {
-		sysFlags |= unix.AT_SYMLINK_NOFOLLOW
-	}
-	err := unix.Fstatat(d.fd, path, &sysStat, sysFlags)
-	return makeFileStat(&sysStat), makeErrno(err)
-}
-
-func (s *System) PathFileStatSetTimes(ctx context.Context, fd wasi.FD, lookupFlags wasi.LookupFlags, path string, accessTime, modifyTime wasi.Timestamp, fstFlags wasi.FSTFlags) wasi.Errno {
-	d, errno := s.lookupFD(fd, wasi.PathFileStatSetTimesRight)
-	if errno != wasi.ESUCCESS {
-		return errno
-	}
-	if fstFlags.Has(wasi.AccessTimeNow) || fstFlags.Has(wasi.ModifyTimeNow) {
-		now := wasi.Timestamp(time.Now().UnixNano())
-		if fstFlags.Has(wasi.AccessTimeNow) {
-			accessTime = now
-		}
-		if fstFlags.Has(wasi.ModifyTimeNow) {
-			modifyTime = now
-		}
-	}
-	var sysFlags int
-	if !lookupFlags.Has(wasi.SymlinkFollow) {
-		sysFlags |= unix.AT_SYMLINK_NOFOLLOW
-	}
-	var ts [2]unix.Timespec
-	changeAccessTime := fstFlags.Has(wasi.AccessTime) || fstFlags.Has(wasi.AccessTimeNow)
-	changeModifyTime := fstFlags.Has(wasi.ModifyTime) || fstFlags.Has(wasi.ModifyTimeNow)
-	if !changeAccessTime || !changeModifyTime {
-		var stat unix.Stat_t
-		err := unix.Fstatat(d.fd, path, &stat, sysFlags)
-		if err != nil {
-			return makeErrno(err)
-		}
-		ts[0] = stat.Atim
-		ts[1] = stat.Mtim
-	}
-	if changeAccessTime {
-		ts[0] = unix.NsecToTimespec(int64(accessTime))
-	}
-	if changeModifyTime {
-		ts[1] = unix.NsecToTimespec(int64(modifyTime))
-	}
-	err := unix.UtimesNanoAt(d.fd, path, ts[:], sysFlags)
-	return makeErrno(err)
-}
-
-func (s *System) PathLink(ctx context.Context, fd wasi.FD, flags wasi.LookupFlags, oldPath string, newFD wasi.FD, newPath string) wasi.Errno {
-	oldDir, errno := s.lookupFD(fd, wasi.PathLinkSourceRight)
-	if errno != wasi.ESUCCESS {
-		return errno
-	}
-	newDir, errno := s.lookupFD(newFD, wasi.PathLinkTargetRight)
-	if errno != wasi.ESUCCESS {
-		return errno
-	}
-	sysFlags := 0
-	if flags.Has(wasi.SymlinkFollow) {
-		sysFlags |= unix.AT_SYMLINK_FOLLOW
-	}
-	err := unix.Linkat(oldDir.fd, oldPath, newDir.fd, newPath, sysFlags)
-	return makeErrno(err)
-}
-
-func (s *System) PathOpen(ctx context.Context, fd wasi.FD, lookupFlags wasi.LookupFlags, path string, openFlags wasi.OpenFlags, rightsBase, rightsInheriting wasi.Rights, fdFlags wasi.FDFlags) (wasi.FD, wasi.Errno) {
-	d, errno := s.lookupFD(fd, wasi.PathOpenRight)
-	if errno != wasi.ESUCCESS {
-		return -1, errno
-	}
-	clean := filepath.Clean(path)
-	if strings.HasPrefix(clean, "/") || strings.HasPrefix(clean, "../") {
-		return -1, wasi.EPERM
-	}
-
-	// Rights can only be preserved or removed, not added.
-	rightsBase &= wasi.AllRights
-	rightsInheriting &= wasi.AllRights
-	if (rightsBase &^ d.stat.RightsInheriting) != 0 {
-		return -1, wasi.ENOTCAPABLE
-	} else if (rightsInheriting &^ d.stat.RightsInheriting) != 0 {
-		return -1, wasi.ENOTCAPABLE
-	}
-	rightsBase &= d.stat.RightsInheriting
-	rightsInheriting &= d.stat.RightsInheriting
-
-	oflags := unix.O_CLOEXEC
-	if openFlags.Has(wasi.OpenDirectory) {
-		oflags |= unix.O_DIRECTORY
-		rightsBase &= wasi.DirectoryRights
-	}
-	if openFlags.Has(wasi.OpenCreate) {
-		if !d.stat.RightsBase.Has(wasi.PathCreateFileRight) {
-			return -1, wasi.ENOTCAPABLE
-		}
-		oflags |= unix.O_CREAT
-	}
-	if openFlags.Has(wasi.OpenExclusive) {
-		oflags |= unix.O_EXCL
-	}
-	if openFlags.Has(wasi.OpenTruncate) {
-		if !d.stat.RightsBase.Has(wasi.PathFileStatSetSizeRight) {
-			return -1, wasi.ENOTCAPABLE
-		}
-		oflags |= unix.O_TRUNC
-	}
-	if fdFlags.Has(wasi.Append) {
-		oflags |= unix.O_APPEND
-	}
-	if fdFlags.Has(wasi.DSync) {
-		oflags |= unix.O_DSYNC
-	}
-	if fdFlags.Has(wasi.Sync) {
-		oflags |= unix.O_SYNC
-	}
-	if fdFlags.Has(wasi.RSync) {
-		// O_RSYNC is not widely supported, and in many cases is an
-		// alias for O_SYNC.
-		oflags |= unix.O_SYNC
-	}
-	if fdFlags.Has(wasi.NonBlock) {
-		oflags |= unix.O_NONBLOCK
-	}
-	if !lookupFlags.Has(wasi.SymlinkFollow) {
-		oflags |= unix.O_NOFOLLOW
-	}
-	switch {
-	case openFlags.Has(wasi.OpenDirectory):
-		oflags |= unix.O_RDONLY
-	case rightsBase.HasAny(wasi.ReadRights) && rightsBase.HasAny(wasi.WriteRights):
-		oflags |= unix.O_RDWR
-	case rightsBase.HasAny(wasi.ReadRights):
-		oflags |= unix.O_RDONLY
-	case rightsBase.HasAny(wasi.WriteRights):
-		oflags |= unix.O_WRONLY
-	default:
-		oflags |= unix.O_RDONLY
-	}
-
-	mode := uint32(0644)
-	fileType := wasi.RegularFileType
-	if (oflags & unix.O_DIRECTORY) != 0 {
-		fileType = wasi.DirectoryType
-		mode = 0
-	}
-	hostfd, err := unix.Openat(d.fd, path, oflags, mode)
-	if err != nil {
-		return -1, makeErrno(err)
-	}
-
-	guestfd := s.fds.Insert(fdinfo{
-		fd: hostfd,
-		stat: wasi.FDStat{
-			FileType:         fileType,
-			Flags:            fdFlags,
-			RightsBase:       rightsBase,
-			RightsInheriting: rightsInheriting,
-		},
-	})
-	return guestfd, wasi.ESUCCESS
-}
-
-func (s *System) PathReadLink(ctx context.Context, fd wasi.FD, path string, buffer []byte) ([]byte, wasi.Errno) {
-	d, errno := s.lookupFD(fd, wasi.PathReadLinkRight)
-	if errno != wasi.ESUCCESS {
-		return buffer, errno
-	}
-	n, err := unix.Readlinkat(d.fd, path, buffer)
-	if err != nil {
-		return buffer, makeErrno(err)
-	} else if n == len(buffer) {
-		return buffer, wasi.ERANGE
-	}
-	return buffer[:n], wasi.ESUCCESS
-}
-
-func (s *System) PathRemoveDirectory(ctx context.Context, fd wasi.FD, path string) wasi.Errno {
-	d, errno := s.lookupFD(fd, wasi.PathRemoveDirectoryRight)
-	if errno != wasi.ESUCCESS {
-		return errno
-	}
-	err := unix.Unlinkat(d.fd, path, unix.AT_REMOVEDIR)
-	return makeErrno(err)
-}
-
-func (s *System) PathRename(ctx context.Context, fd wasi.FD, oldPath string, newFD wasi.FD, newPath string) wasi.Errno {
-	oldDir, errno := s.lookupFD(fd, wasi.PathRenameSourceRight)
-	if errno != wasi.ESUCCESS {
-		return errno
-	}
-	newDir, errno := s.lookupFD(newFD, wasi.PathRenameTargetRight)
-	if errno != wasi.ESUCCESS {
-		return errno
-	}
-	err := unix.Renameat(oldDir.fd, oldPath, newDir.fd, newPath)
-	return makeErrno(err)
-}
-
-func (s *System) PathSymlink(ctx context.Context, oldPath string, fd wasi.FD, newPath string) wasi.Errno {
-	d, errno := s.lookupFD(fd, wasi.PathSymlinkRight)
-	if errno != wasi.ESUCCESS {
-		return errno
-	}
-	err := unix.Symlinkat(oldPath, d.fd, newPath)
-	return makeErrno(err)
-}
-
-func (s *System) PathUnlinkFile(ctx context.Context, fd wasi.FD, path string) wasi.Errno {
-	d, errno := s.lookupFD(fd, wasi.PathUnlinkFileRight)
-	if errno != wasi.ESUCCESS {
-		return errno
-	}
-	err := unix.Unlinkat(d.fd, path, 0)
-	return makeErrno(err)
-}
-
 func (s *System) PollOneOff(ctx context.Context, subscriptions []wasi.Subscription, events []wasi.Event) (int, wasi.Errno) {
 	if len(subscriptions) == 0 || len(events) < len(subscriptions) {
 		return 0, wasi.EINVAL
@@ -750,7 +147,7 @@ func (s *System) PollOneOff(ctx context.Context, subscriptions []wasi.Subscripti
 
 		switch sub.EventType {
 		case wasi.FDReadEvent, wasi.FDWriteEvent:
-			f, errno := s.lookupFD(sub.GetFDReadWrite().FD, wasi.PollFDReadWriteRight)
+			fd, _, errno := s.LookupFD(sub.GetFDReadWrite().FD, wasi.PollFDReadWriteRight)
 			if errno != wasi.ESUCCESS {
 				events[i] = errorEvent(sub, errno)
 				numEvents++
@@ -761,7 +158,7 @@ func (s *System) PollOneOff(ctx context.Context, subscriptions []wasi.Subscripti
 				pollevent = unix.POLLOUT
 			}
 			s.pollfds = append(s.pollfds, unix.PollFd{
-				Fd:     int32(f.fd),
+				Fd:     int32(fd),
 				Events: pollevent,
 			})
 
@@ -946,7 +343,7 @@ func (s *System) RandomGet(ctx context.Context, b []byte) wasi.Errno {
 }
 
 func (s *System) SockAccept(ctx context.Context, fd wasi.FD, flags wasi.FDFlags) (wasi.FD, wasi.SocketAddress, wasi.SocketAddress, wasi.Errno) {
-	socket, errno := s.lookupSocketFD(fd, wasi.SockAcceptRight)
+	socket, stat, errno := s.LookupSocketFD(fd, wasi.SockAcceptRight)
 	if errno != wasi.ESUCCESS {
 		return -1, nil, nil, errno
 	}
@@ -961,7 +358,7 @@ func (s *System) SockAccept(ctx context.Context, fd wasi.FD, flags wasi.FDFlags)
 	if (flags & wasi.NonBlock) != 0 {
 		connflags |= unix.O_NONBLOCK
 	}
-	connfd, sa, err := accept(socket.fd, connflags)
+	connfd, sa, err := accept(int(socket), connflags)
 	if err != nil {
 		return -1, nil, nil, makeErrno(err)
 	}
@@ -970,20 +367,17 @@ func (s *System) SockAccept(ctx context.Context, fd wasi.FD, flags wasi.FDFlags)
 		unix.Close(connfd)
 		return -1, nil, nil, wasi.ENOTSUP
 	}
-	guestfd := s.fds.Insert(fdinfo{
-		fd: connfd,
-		stat: wasi.FDStat{
-			FileType:         wasi.SocketStreamType,
-			Flags:            flags,
-			RightsBase:       socket.stat.RightsInheriting,
-			RightsInheriting: socket.stat.RightsInheriting,
-		},
+	guestfd := s.Register(FD(connfd), wasi.FDStat{
+		FileType:         wasi.SocketStreamType,
+		Flags:            flags,
+		RightsBase:       stat.RightsInheriting,
+		RightsInheriting: stat.RightsInheriting,
 	})
 	return guestfd, peer, addr, wasi.ESUCCESS
 }
 
 func (s *System) SockRecv(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec, flags wasi.RIFlags) (wasi.Size, wasi.ROFlags, wasi.Errno) {
-	socket, errno := s.lookupSocketFD(fd, wasi.FDReadRight)
+	socket, _, errno := s.LookupSocketFD(fd, wasi.FDReadRight)
 	if errno != wasi.ESUCCESS {
 		return 0, 0, errno
 	}
@@ -994,7 +388,7 @@ func (s *System) SockRecv(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec, 
 	if flags.Has(wasi.RecvWaitAll) {
 		sysIFlags |= unix.MSG_WAITALL
 	}
-	n, _, sysOFlags, _, err := unix.RecvmsgBuffers(socket.fd, makeIOVecs(iovecs), nil, sysIFlags)
+	n, _, sysOFlags, _, err := unix.RecvmsgBuffers(int(socket), makeIOVecs(iovecs), nil, sysIFlags)
 	var roflags wasi.ROFlags
 	if (sysOFlags & unix.MSG_TRUNC) != 0 {
 		roflags |= wasi.RecvDataTruncated
@@ -1003,16 +397,16 @@ func (s *System) SockRecv(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec, 
 }
 
 func (s *System) SockSend(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec, flags wasi.SIFlags) (wasi.Size, wasi.Errno) {
-	socket, errno := s.lookupSocketFD(fd, wasi.FDWriteRight)
+	socket, _, errno := s.LookupSocketFD(fd, wasi.FDWriteRight)
 	if errno != wasi.ESUCCESS {
 		return 0, errno
 	}
-	n, err := unix.SendmsgBuffers(socket.fd, makeIOVecs(iovecs), nil, nil, 0)
+	n, err := unix.SendmsgBuffers(int(socket), makeIOVecs(iovecs), nil, nil, 0)
 	return wasi.Size(n), makeErrno(err)
 }
 
 func (s *System) SockShutdown(ctx context.Context, fd wasi.FD, flags wasi.SDFlags) wasi.Errno {
-	socket, errno := s.lookupSocketFD(fd, wasi.SockShutdownRight)
+	socket, _, errno := s.LookupSocketFD(fd, wasi.SockShutdownRight)
 	if errno != wasi.ESUCCESS {
 		return errno
 	}
@@ -1027,7 +421,7 @@ func (s *System) SockShutdown(ctx context.Context, fd wasi.FD, flags wasi.SDFlag
 	default:
 		return wasi.EINVAL
 	}
-	err := unix.Shutdown(socket.fd, sysHow)
+	err := unix.Shutdown(int(socket), sysHow)
 	return makeErrno(err)
 }
 
@@ -1068,19 +462,16 @@ func (s *System) SockOpen(ctx context.Context, pf wasi.ProtocolFamily, socketTyp
 	if err != nil {
 		return -1, makeErrno(err)
 	}
-	guestfd := s.fds.Insert(fdinfo{
-		fd: fd,
-		stat: wasi.FDStat{
-			FileType:         fdType,
-			RightsBase:       rightsBase,
-			RightsInheriting: rightsInheriting,
-		},
+	guestfd := s.Register(FD(fd), wasi.FDStat{
+		FileType:         fdType,
+		RightsBase:       rightsBase,
+		RightsInheriting: rightsInheriting,
 	})
 	return guestfd, wasi.ESUCCESS
 }
 
 func (s *System) SockBind(ctx context.Context, fd wasi.FD, addr wasi.SocketAddress) (wasi.SocketAddress, wasi.Errno) {
-	socket, errno := s.lookupSocketFD(fd, wasi.SockAcceptRight)
+	socket, _, errno := s.LookupSocketFD(fd, wasi.SockAcceptRight)
 	if errno != wasi.ESUCCESS {
 		return nil, errno
 	}
@@ -1088,14 +479,14 @@ func (s *System) SockBind(ctx context.Context, fd wasi.FD, addr wasi.SocketAddre
 	if !ok {
 		return nil, wasi.EINVAL
 	}
-	if err := unix.Bind(socket.fd, sa); err != nil {
+	if err := unix.Bind(int(socket), sa); err != nil {
 		return nil, makeErrno(err)
 	}
 	return s.SockLocalAddress(ctx, fd)
 }
 
 func (s *System) SockConnect(ctx context.Context, fd wasi.FD, peer wasi.SocketAddress) (wasi.SocketAddress, wasi.Errno) {
-	socket, errno := s.lookupSocketFD(fd, 0)
+	socket, _, errno := s.LookupSocketFD(fd, 0)
 	if errno != wasi.ESUCCESS {
 		return nil, errno
 	}
@@ -1103,7 +494,7 @@ func (s *System) SockConnect(ctx context.Context, fd wasi.FD, peer wasi.SocketAd
 	if !ok {
 		return nil, wasi.EINVAL
 	}
-	err := unix.Connect(socket.fd, sa)
+	err := unix.Connect(int(socket), sa)
 	if err != nil && err != unix.EINPROGRESS {
 		return nil, makeErrno(err)
 	}
@@ -1115,16 +506,16 @@ func (s *System) SockConnect(ctx context.Context, fd wasi.FD, peer wasi.SocketAd
 }
 
 func (s *System) SockListen(ctx context.Context, fd wasi.FD, backlog int) wasi.Errno {
-	socket, errno := s.lookupSocketFD(fd, wasi.SockAcceptRight)
+	socket, _, errno := s.LookupSocketFD(fd, wasi.SockAcceptRight)
 	if errno != wasi.ESUCCESS {
 		return errno
 	}
-	err := unix.Listen(socket.fd, backlog)
+	err := unix.Listen(int(socket), backlog)
 	return makeErrno(err)
 }
 
 func (s *System) SockSendTo(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec, flags wasi.SIFlags, addr wasi.SocketAddress) (wasi.Size, wasi.Errno) {
-	socket, errno := s.lookupSocketFD(fd, wasi.FDWriteRight)
+	socket, _, errno := s.LookupSocketFD(fd, wasi.FDWriteRight)
 	if errno != wasi.ESUCCESS {
 		return 0, errno
 	}
@@ -1132,12 +523,12 @@ func (s *System) SockSendTo(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec
 	if !ok {
 		return 0, wasi.EINVAL
 	}
-	n, err := unix.SendmsgBuffers(socket.fd, makeIOVecs(iovecs), nil, sa, 0)
+	n, err := unix.SendmsgBuffers(int(socket), makeIOVecs(iovecs), nil, sa, 0)
 	return wasi.Size(n), makeErrno(err)
 }
 
 func (s *System) SockRecvFrom(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec, flags wasi.RIFlags) (wasi.Size, wasi.ROFlags, wasi.SocketAddress, wasi.Errno) {
-	socket, errno := s.lookupSocketFD(fd, wasi.FDReadRight)
+	socket, _, errno := s.LookupSocketFD(fd, wasi.FDReadRight)
 	if errno != wasi.ESUCCESS {
 		return 0, 0, nil, errno
 	}
@@ -1148,7 +539,7 @@ func (s *System) SockRecvFrom(ctx context.Context, fd wasi.FD, iovecs []wasi.IOV
 	if flags.Has(wasi.RecvWaitAll) {
 		sysIFlags |= unix.MSG_WAITALL
 	}
-	n, _, sysOFlags, sa, err := unix.RecvmsgBuffers(socket.fd, makeIOVecs(iovecs), nil, sysIFlags)
+	n, _, sysOFlags, sa, err := unix.RecvmsgBuffers(int(socket), makeIOVecs(iovecs), nil, sysIFlags)
 	var addr wasi.SocketAddress
 	if sa != nil {
 		var ok bool
@@ -1165,7 +556,7 @@ func (s *System) SockRecvFrom(ctx context.Context, fd wasi.FD, iovecs []wasi.IOV
 }
 
 func (s *System) SockGetOptInt(ctx context.Context, fd wasi.FD, level wasi.SocketOptionLevel, option wasi.SocketOption) (int, wasi.Errno) {
-	socket, errno := s.lookupSocketFD(fd, 0)
+	socket, _, errno := s.LookupSocketFD(fd, 0)
 	if errno != wasi.ESUCCESS {
 		return 0, errno
 	}
@@ -1207,7 +598,7 @@ func (s *System) SockGetOptInt(ctx context.Context, fd wasi.FD, level wasi.Socke
 		return 0, wasi.EINVAL
 	}
 
-	value, err := unix.GetsockoptInt(socket.fd, sysLevel, sysOption)
+	value, err := unix.GetsockoptInt(int(socket), sysLevel, sysOption)
 	if err != nil {
 		return 0, makeErrno(err)
 	}
@@ -1232,7 +623,7 @@ func (s *System) SockGetOptInt(ctx context.Context, fd wasi.FD, level wasi.Socke
 }
 
 func (s *System) SockSetOptInt(ctx context.Context, fd wasi.FD, level wasi.SocketOptionLevel, option wasi.SocketOption, value int) wasi.Errno {
-	socket, errno := s.lookupSocketFD(fd, 0)
+	socket, _, errno := s.LookupSocketFD(fd, 0)
 	if errno != wasi.ESUCCESS {
 		return errno
 	}
@@ -1273,16 +664,16 @@ func (s *System) SockSetOptInt(ctx context.Context, fd wasi.FD, level wasi.Socke
 	default:
 		return wasi.EINVAL
 	}
-	err := unix.SetsockoptInt(socket.fd, sysLevel, sysOption, value)
+	err := unix.SetsockoptInt(int(socket), sysLevel, sysOption, value)
 	return makeErrno(err)
 }
 
 func (s *System) SockLocalAddress(ctx context.Context, fd wasi.FD) (wasi.SocketAddress, wasi.Errno) {
-	socket, errno := s.lookupSocketFD(fd, 0)
+	socket, _, errno := s.LookupSocketFD(fd, 0)
 	if errno != wasi.ESUCCESS {
 		return nil, errno
 	}
-	sa, err := unix.Getsockname(socket.fd)
+	sa, err := unix.Getsockname(int(socket))
 	if err != nil {
 		return nil, makeErrno(err)
 	}
@@ -1294,11 +685,11 @@ func (s *System) SockLocalAddress(ctx context.Context, fd wasi.FD) (wasi.SocketA
 }
 
 func (s *System) SockRemoteAddress(ctx context.Context, fd wasi.FD) (wasi.SocketAddress, wasi.Errno) {
-	socket, errno := s.lookupSocketFD(fd, 0)
+	socket, _, errno := s.LookupSocketFD(fd, 0)
 	if errno != wasi.ESUCCESS {
 		return nil, errno
 	}
-	sa, err := unix.Getpeername(socket.fd)
+	sa, err := unix.Getpeername(int(socket))
 	if err != nil {
 		return nil, makeErrno(err)
 	}
@@ -1310,12 +701,7 @@ func (s *System) SockRemoteAddress(ctx context.Context, fd wasi.FD) (wasi.Socket
 }
 
 func (s *System) Close(ctx context.Context) error {
-	s.fds.Range(func(fd wasi.FD, f fdinfo) bool {
-		unix.Close(f.fd)
-		return true
-	})
-	s.fds.Reset()
-	s.preopens.Reset()
+	err := s.FileTable.Close(ctx)
 
 	s.mutex.Lock()
 	fd0 := s.shutfds[0]
@@ -1328,7 +714,7 @@ func (s *System) Close(ctx context.Context) error {
 		unix.Close(fd0)
 		unix.Close(fd1)
 	}
-	return nil
+	return err
 }
 
 // Shutdown may be called to asynchronously cancel all blocking operations on

--- a/systems/unix/system_test.go
+++ b/systems/unix/system_test.go
@@ -55,22 +55,22 @@ func TestWASIP1(t *testing.T) {
 				return nil, nil, err
 			}
 
-			s.Preopen(stdin, "/dev/stdin", wasi.FDStat{
+			s.Preopen(unix.FD(stdin), "/dev/stdin", wasi.FDStat{
 				FileType:   wasi.CharacterDeviceType,
 				RightsBase: wasi.AllRights,
 			})
 
-			s.Preopen(stdout, "/dev/stdout", wasi.FDStat{
+			s.Preopen(unix.FD(stdout), "/dev/stdout", wasi.FDStat{
 				FileType:   wasi.CharacterDeviceType,
 				RightsBase: wasi.AllRights,
 			})
 
-			s.Preopen(stderr, "/dev/stderr", wasi.FDStat{
+			s.Preopen(unix.FD(stderr), "/dev/stderr", wasi.FDStat{
 				FileType:   wasi.CharacterDeviceType,
 				RightsBase: wasi.AllRights,
 			})
 
-			s.Preopen(root, "/", wasi.FDStat{
+			s.Preopen(unix.FD(root), "/", wasi.FDStat{
 				FileType:         wasi.DirectoryType,
 				RightsBase:       wasi.AllRights,
 				RightsInheriting: wasi.AllRights,
@@ -213,8 +213,8 @@ func testSystem(f func(context.Context, *unix.System)) {
 	if err != nil {
 		panic(err)
 	}
-	p.Preopen(int(r.Fd()), "fd0", wasi.FDStat{RightsBase: wasi.AllRights})
-	p.Preopen(int(w.Fd()), "fd1", wasi.FDStat{RightsBase: wasi.AllRights})
+	p.Preopen(unix.FD(r.Fd()), "fd0", wasi.FDStat{RightsBase: wasi.AllRights})
+	p.Preopen(unix.FD(w.Fd()), "fd1", wasi.FDStat{RightsBase: wasi.AllRights})
 
 	f(ctx, p)
 }

--- a/tracer.go
+++ b/tracer.go
@@ -15,24 +15,6 @@ type Tracer struct {
 var _ System = (*Tracer)(nil)
 var _ SocketsExtension = (*Tracer)(nil)
 
-func (t *Tracer) Preopen(hostfd int, path string, fdstat FDStat) FD {
-	t.printf("Preopen(%d, %q, ", hostfd, path)
-	t.printFDStat(fdstat)
-	t.printf(") => ")
-	fd := t.System.Preopen(hostfd, path, fdstat)
-	t.printf("%d\n", fd)
-	return fd
-}
-
-func (t *Tracer) Register(hostfd int, fdstat FDStat) FD {
-	t.printf("Register(%d, ", hostfd)
-	t.printFDStat(fdstat)
-	t.printf(") => ")
-	fd := t.System.Register(hostfd, fdstat)
-	t.printf("%d\n", fd)
-	return fd
-}
-
 func (t *Tracer) ArgsSizesGet(ctx context.Context) (int, int, Errno) {
 	t.printf("ArgsSizesGet() => ")
 	argCount, stringBytes, errno := t.System.ArgsSizesGet(ctx)
@@ -415,16 +397,16 @@ func (t *Tracer) PathOpen(ctx context.Context, fd FD, dirFlags LookupFlags, path
 	return fd, errno
 }
 
-func (t *Tracer) PathReadLink(ctx context.Context, fd FD, path string, buffer []byte) ([]byte, Errno) {
+func (t *Tracer) PathReadLink(ctx context.Context, fd FD, path string, buffer []byte) (int, Errno) {
 	t.printf("PathReadLink(%d, %q, [%d]byte) => ", fd, path, len(buffer))
-	result, errno := t.System.PathReadLink(ctx, fd, path, buffer)
+	n, errno := t.System.PathReadLink(ctx, fd, path, buffer)
 	if errno == ESUCCESS {
-		t.printBytes(result)
+		t.printBytes(buffer[:n])
 	} else {
 		t.printErrno(errno)
 	}
 	t.printf("\n")
-	return result, errno
+	return n, errno
 }
 
 func (t *Tracer) PathRemoveDirectory(ctx context.Context, fd FD, path string) Errno {

--- a/wasi.go
+++ b/wasi.go
@@ -1,0 +1,643 @@
+package wasi
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/stealthrocket/wasi-go/internal/descriptor"
+)
+
+// File is an interface used as constraint in the FileType generic type
+// parameter.
+//
+// File implement the WASI functions which operate on a file descriptor number.
+type File[T any] interface {
+	FDAdvise(ctx context.Context, offset, length FileSize, advice Advice) Errno
+
+	FDAllocate(ctx context.Context, offset, length FileSize) Errno
+
+	FDClose(ctx context.Context) Errno
+
+	FDDataSync(ctx context.Context) Errno
+
+	FDStatSetFlags(ctx context.Context, flags FDFlags) Errno
+
+	FDFileStatGet(ctx context.Context) (FileStat, Errno)
+
+	FDFileStatSetSize(ctx context.Context, size FileSize) Errno
+
+	FDFileStatSetTimes(ctx context.Context, accessTime, modifyTime Timestamp) Errno
+
+	FDPread(ctx context.Context, iovecs []IOVec, offset FileSize) (Size, Errno)
+
+	FDPwrite(ctx context.Context, iovecs []IOVec, offset FileSize) (Size, Errno)
+
+	FDRead(ctx context.Context, iovecs []IOVec) (Size, Errno)
+
+	FDWrite(ctx context.Context, iovecs []IOVec) (Size, Errno)
+
+	FDSync(ctx context.Context) Errno
+
+	FDSeek(ctx context.Context, delta FileDelta, whence Whence) (FileSize, Errno)
+
+	FDOpenDir(ctx context.Context) (Dir, Errno)
+
+	PathCreateDirectory(ctx context.Context, path string) Errno
+
+	PathFileStatGet(ctx context.Context, flags LookupFlags, path string) (FileStat, Errno)
+
+	PathFileStatSetTimes(ctx context.Context, lookupFlags LookupFlags, path string, accessTime, modifyTime Timestamp) Errno
+
+	PathLink(ctx context.Context, flags LookupFlags, oldPath string, newFile T, newPath string) Errno
+
+	PathOpen(ctx context.Context, lookupFlags LookupFlags, path string, openFlags OpenFlags, rightsBase, rightsInheriting Rights, fdFlags FDFlags) (T, Errno)
+
+	PathReadLink(ctx context.Context, path string, buffer []byte) (int, Errno)
+
+	PathRemoveDirectory(ctx context.Context, path string) Errno
+
+	PathRename(ctx context.Context, oldPath string, newFile T, newPath string) Errno
+
+	PathSymlink(ctx context.Context, oldPath string, newPath string) Errno
+
+	PathUnlinkFile(ctx context.Context, path string) Errno
+}
+
+// Dir instances are returned by File.FDOpenDir and used to iterate over
+type Dir interface {
+	FDReadDir(ctx context.Context, entries []DirEntry, cookie DirCookie, bufferSizeBytes int) (int, Errno)
+
+	FDCloseDir(ctx context.Context) Errno
+}
+
+// FileTable is a building block used to construct implementations of the System
+// interface.
+//
+// The file table maintains the set of open files and associates them with file
+// descriptor numbers.
+//
+// The type paritally implements the System interface, it is common to embed
+// a FileTable field in a struct in order to inherit its methods. The generic
+// type allows for specialization of the behavior of files, for example:
+//
+//	// System embeds a wasi.FileTable to implements most of the wasi.System
+//	// interface methods.
+//	type System struct {
+//		wasi.FileTable[File]
+//		...
+//	}
+//
+//	// File implements the wasi.File interface to specialize the behavior of
+//	// WASI functions.
+//	type File struct {
+//		...
+//	}
+type FileTable[T File[T]] struct {
+	files    descriptor.Table[FD, fileInfo[T]]
+	preopens descriptor.Table[FD, string]
+	dirs     map[FD]Dir
+}
+
+type fileInfo[T File[T]] struct {
+	file T
+	stat FDStat
+}
+
+func (t *FileTable[T]) Close(ctx context.Context) error {
+	t.files.Range(func(fd FD, f fileInfo[T]) bool {
+		f.file.FDClose(ctx)
+		return true
+	})
+	t.files.Reset()
+	t.preopens.Reset()
+	for _, dir := range t.dirs {
+		dir.FDCloseDir(ctx)
+	}
+	for fd := range t.dirs {
+		delete(t.dirs, fd)
+	}
+	return nil
+}
+
+func (t *FileTable[T]) Preopen(file T, path string, stat FDStat) FD {
+	fd := t.Register(file, stat)
+	t.preopens.Assign(fd, path)
+	return fd
+}
+
+func (t *FileTable[T]) Register(file T, stat FDStat) FD {
+	stat.RightsBase &= AllRights
+	stat.RightsInheriting &= AllRights
+	return t.files.Insert(fileInfo[T]{file: file, stat: stat})
+}
+
+func (t *FileTable[T]) LookupFD(fd FD, rights Rights) (file T, stat FDStat, errno Errno) {
+	f, errno := t.lookupFD(fd, rights)
+	if f != nil {
+		file = f.file
+		stat = f.stat
+	}
+	return file, stat, errno
+}
+
+func (t *FileTable[T]) LookupSocketFD(fd FD, rights Rights) (file T, stat FDStat, errno Errno) {
+	f, errno := t.lookupSocketFD(fd, rights)
+	if f != nil {
+		file = f.file
+		stat = f.stat
+	}
+	return file, stat, errno
+}
+
+func (t *FileTable[T]) isPreopen(fd FD) bool {
+	return t.preopens.Access(fd) != nil
+}
+
+func (t *FileTable[T]) lookupFD(fd FD, rights Rights) (*fileInfo[T], Errno) {
+	f := t.files.Access(fd)
+	if f == nil {
+		return nil, EBADF
+	}
+	if !f.stat.RightsBase.Has(rights) {
+		return nil, ENOTCAPABLE
+	}
+	return f, ESUCCESS
+}
+
+func (t *FileTable[T]) lookupPreopenPath(fd FD) (string, Errno) {
+	path, ok := t.preopens.Lookup(fd)
+	if !ok {
+		return "", EBADF
+	}
+	f := t.files.Access(fd)
+	if f == nil {
+		return "", EBADF
+	}
+	if f.stat.FileType != DirectoryType {
+		return "", ENOTDIR
+	}
+	return path, ESUCCESS
+}
+
+func (t *FileTable[T]) lookupSocketFD(fd FD, rights Rights) (*fileInfo[T], Errno) {
+	f := t.files.Access(fd)
+	if f == nil {
+		return nil, EBADF
+	}
+	switch f.stat.FileType {
+	case SocketStreamType:
+	case SocketDGramType:
+	default:
+		return nil, ENOTSOCK
+	}
+	if !f.stat.RightsBase.Has(rights) {
+		return nil, ENOTCAPABLE
+	}
+	return f, ESUCCESS
+}
+
+func (t *FileTable[T]) FDAdvise(ctx context.Context, fd FD, offset FileSize, length FileSize, advice Advice) Errno {
+	f, errno := t.lookupFD(fd, FDAdviseRight)
+	if errno != ESUCCESS {
+		return errno
+	}
+	return f.file.FDAdvise(ctx, offset, length, advice)
+}
+
+func (t *FileTable[T]) FDAllocate(ctx context.Context, fd FD, offset FileSize, length FileSize) Errno {
+	f, errno := t.lookupFD(fd, FDAllocateRight)
+	if errno != ESUCCESS {
+		return errno
+	}
+	return f.file.FDAllocate(ctx, offset, length)
+}
+
+func (t *FileTable[T]) FDClose(ctx context.Context, fd FD) Errno {
+	f, errno := t.lookupFD(fd, 0)
+	if errno != ESUCCESS {
+		return errno
+	}
+	t.files.Delete(fd)
+	// Note: closing pre-opens is allowed.
+	// See github.com/WebAssembly/wasi-testsuite/blob/1b1d4a5/tests/rust/src/bin/close_preopen.rs
+	t.preopens.Delete(fd)
+	if dir := t.dirs[fd]; dir != nil {
+		delete(t.dirs, fd)
+		dir.FDCloseDir(ctx)
+	}
+	return f.file.FDClose(ctx)
+}
+
+func (t *FileTable[T]) FDDataSync(ctx context.Context, fd FD) Errno {
+	f, errno := t.lookupFD(fd, FDDataSyncRight)
+	if errno != ESUCCESS {
+		return errno
+	}
+	return f.file.FDDataSync(ctx)
+}
+
+func (t *FileTable[T]) FDStatGet(ctx context.Context, fd FD) (FDStat, Errno) {
+	f, errno := t.lookupFD(fd, 0)
+	if errno != ESUCCESS {
+		return FDStat{}, errno
+	}
+	return f.stat, ESUCCESS
+}
+
+func (t *FileTable[T]) FDStatSetFlags(ctx context.Context, fd FD, flags FDFlags) Errno {
+	f, errno := t.lookupFD(fd, FDStatSetFlagsRight)
+	if errno != ESUCCESS {
+		return errno
+	}
+	changes := flags ^ f.stat.Flags
+	if changes == 0 {
+		return ESUCCESS
+	}
+	if changes.Has(Sync | DSync | RSync) {
+		return ENOSYS // TODO: support changing {Sync,DSync,Rsync}
+	}
+	if errno := f.file.FDStatSetFlags(ctx, flags); errno != ESUCCESS {
+		return errno
+	}
+	f.stat.Flags ^= changes
+	return ESUCCESS
+}
+
+func (t *FileTable[T]) FDStatSetRights(ctx context.Context, fd FD, rightsBase, rightsInheriting Rights) Errno {
+	f, errno := t.lookupFD(fd, 0)
+	if errno != ESUCCESS {
+		return errno
+	}
+	// Rights can only be preserved or removed, not added.
+	rightsBase &= AllRights
+	rightsInheriting &= AllRights
+	if (rightsBase &^ f.stat.RightsBase) != 0 {
+		return ENOTCAPABLE
+	}
+	if (rightsInheriting &^ f.stat.RightsInheriting) != 0 {
+		return ENOTCAPABLE
+	}
+	f.stat.RightsBase &= rightsBase
+	f.stat.RightsInheriting &= rightsInheriting
+	return ESUCCESS
+}
+
+func (t *FileTable[T]) FDFileStatSetSize(ctx context.Context, fd FD, size FileSize) Errno {
+	f, errno := t.lookupFD(fd, FDFileStatSetSizeRight)
+	if errno != ESUCCESS {
+		return errno
+	}
+	return f.file.FDFileStatSetSize(ctx, size)
+}
+
+func (t *FileTable[T]) FDFileStatGet(ctx context.Context, fd FD) (FileStat, Errno) {
+	f, errno := t.lookupFD(fd, FDFileStatGetRight)
+	if errno != ESUCCESS {
+		return FileStat{}, errno
+	}
+	s, errno := f.file.FDFileStatGet(ctx)
+	if errno != ESUCCESS {
+		return FileStat{}, errno
+	}
+	if fd <= 2 {
+		// Override stdio size/times.
+		// See github.com/WebAssembly/wasi-testsuite/blob/1b1d4a5/tests/rust/src/bin/fd_filestat_get.rs
+		s.Size = 0
+		s.AccessTime = 0
+		s.ModifyTime = 0
+		s.ChangeTime = 0
+	}
+	return s, ESUCCESS
+}
+
+func (t *FileTable[T]) FDFileStatSetTimes(ctx context.Context, fd FD, accessTime, modifyTime Timestamp, flags FSTFlags) Errno {
+	f, errno := t.lookupFD(fd, FDFileStatSetTimesRight)
+	if errno != ESUCCESS {
+		return errno
+	}
+	if flags.Has(AccessTimeNow) || flags.Has(ModifyTimeNow) {
+		timestamp := Timestamp(time.Now().UnixNano())
+		if flags.Has(AccessTimeNow) {
+			accessTime = timestamp
+		}
+		if flags.Has(ModifyTimeNow) {
+			modifyTime = timestamp
+		}
+	}
+	changeAccessTime := flags.Has(AccessTime) || flags.Has(AccessTimeNow)
+	changeModifyTime := flags.Has(ModifyTime) || flags.Has(ModifyTimeNow)
+	if !changeAccessTime && !changeModifyTime {
+		return ESUCCESS
+	}
+	if !changeAccessTime || !changeModifyTime {
+		stat, errno := f.file.FDFileStatGet(ctx)
+		if errno != ESUCCESS {
+			return errno
+		}
+		if !changeAccessTime {
+			accessTime = stat.AccessTime
+		}
+		if !changeAccessTime {
+			modifyTime = stat.ModifyTime
+		}
+	}
+	return f.file.FDFileStatSetTimes(ctx, accessTime, modifyTime)
+}
+
+func (t *FileTable[T]) FDPreStatGet(ctx context.Context, fd FD) (PreStat, Errno) {
+	path, errno := t.lookupPreopenPath(fd)
+	if errno != ESUCCESS {
+		return PreStat{}, errno
+	}
+	stat := PreStat{
+		Type: PreOpenDir,
+		PreStatDir: PreStatDir{
+			NameLength: Size(len(path)),
+		},
+	}
+	return stat, ESUCCESS
+}
+
+func (t *FileTable[T]) FDPreStatDirName(ctx context.Context, fd FD) (string, Errno) {
+	return t.lookupPreopenPath(fd)
+}
+
+func (t *FileTable[T]) FDPread(ctx context.Context, fd FD, iovecs []IOVec, offset FileSize) (Size, Errno) {
+	f, errno := t.lookupFD(fd, FDReadRight|FDSeekRight)
+	if errno != ESUCCESS {
+		return 0, errno
+	}
+	return f.file.FDPread(ctx, iovecs, offset)
+}
+
+func (t *FileTable[T]) FDPwrite(ctx context.Context, fd FD, iovecs []IOVec, offset FileSize) (Size, Errno) {
+	f, errno := t.lookupFD(fd, FDWriteRight|FDSeekRight)
+	if errno != ESUCCESS {
+		return 0, errno
+	}
+	return f.file.FDPwrite(ctx, iovecs, offset)
+}
+
+func (t *FileTable[T]) FDRead(ctx context.Context, fd FD, iovecs []IOVec) (Size, Errno) {
+	f, errno := t.lookupFD(fd, FDReadRight)
+	if errno != ESUCCESS {
+		return 0, errno
+	}
+	return f.file.FDRead(ctx, iovecs)
+}
+
+func (t *FileTable[T]) FDWrite(ctx context.Context, fd FD, iovecs []IOVec) (Size, Errno) {
+	f, errno := t.lookupFD(fd, FDWriteRight)
+	if errno != ESUCCESS {
+		return 0, errno
+	}
+	return f.file.FDWrite(ctx, iovecs)
+}
+
+func (t *FileTable[T]) FDReadDir(ctx context.Context, fd FD, entries []DirEntry, cookie DirCookie, bufferSizeBytes int) (int, Errno) {
+	f, errno := t.lookupFD(fd, FDReadDirRight)
+	if errno != ESUCCESS {
+		return 0, errno
+	}
+	if len(entries) == 0 {
+		return 0, EINVAL
+	}
+	d := t.dirs[fd]
+	if d == nil {
+		d, errno = f.file.FDOpenDir(ctx)
+		if errno != ESUCCESS {
+			return 0, errno
+		}
+		if t.dirs == nil {
+			t.dirs = make(map[FD]Dir)
+		}
+		t.dirs[fd] = d
+	}
+	return d.FDReadDir(ctx, entries, cookie, bufferSizeBytes)
+}
+
+func (t *FileTable[T]) FDRenumber(ctx context.Context, from, to FD) Errno {
+	if t.isPreopen(from) || t.isPreopen(to) {
+		return ENOTSUP
+	}
+	f, errno := t.lookupFD(from, 0)
+	if errno != ESUCCESS {
+		return errno
+	}
+	d := t.dirs[from]
+	// TODO: limit max file descriptor number
+	g, replaced := t.files.Assign(to, *f)
+	if replaced {
+		g.file.FDClose(ctx)
+		if dir := t.dirs[to]; dir != nil {
+			dir.FDCloseDir(ctx)
+		}
+	}
+	t.files.Delete(from)
+	if d != nil {
+		delete(t.dirs, from)
+		t.dirs[to] = d
+	}
+	return ESUCCESS
+}
+
+func (t *FileTable[T]) FDSync(ctx context.Context, fd FD) Errno {
+	f, errno := t.lookupFD(fd, FDSyncRight)
+	if errno != ESUCCESS {
+		return errno
+	}
+	return f.file.FDSync(ctx)
+}
+
+func (t *FileTable[T]) FDSeek(ctx context.Context, fd FD, delta FileDelta, whence Whence) (FileSize, Errno) {
+	// Note: FDSeekRight implies FDTellRight. FDTellRight also includes the
+	// right to invoke FDSeek in such a way that the file offset remains
+	// unaltered.
+	f, errno := t.lookupFD(fd, FDSeekRight)
+	if errno != ESUCCESS {
+		if errno != ENOTCAPABLE || (delta != 0 && whence != SeekCurrent) {
+			return 0, errno
+		}
+		f, errno = t.lookupFD(fd, FDTellRight)
+		if errno != ESUCCESS {
+			return 0, errno
+		}
+	}
+	return f.file.FDSeek(ctx, delta, whence)
+}
+
+func (t *FileTable[T]) FDTell(ctx context.Context, fd FD) (FileSize, Errno) {
+	return t.FDSeek(ctx, fd, 0, SeekCurrent)
+}
+
+func (t *FileTable[T]) PathCreateDirectory(ctx context.Context, fd FD, path string) Errno {
+	d, errno := t.lookupFD(fd, PathCreateDirectoryRight)
+	if errno != ESUCCESS {
+		return errno
+	}
+	return d.file.PathCreateDirectory(ctx, path)
+}
+
+func (t *FileTable[T]) PathFileStatGet(ctx context.Context, fd FD, lookupFlags LookupFlags, path string) (FileStat, Errno) {
+	d, errno := t.lookupFD(fd, PathFileStatGetRight)
+	if errno != ESUCCESS {
+		return FileStat{}, errno
+	}
+	return d.file.PathFileStatGet(ctx, lookupFlags, path)
+}
+
+func (t *FileTable[T]) PathFileStatSetTimes(ctx context.Context, fd FD, lookupFlags LookupFlags, path string, accessTime, modifyTime Timestamp, fstFlags FSTFlags) Errno {
+	d, errno := t.lookupFD(fd, PathFileStatSetTimesRight)
+	if errno != ESUCCESS {
+		return errno
+	}
+	if fstFlags.Has(AccessTimeNow) || fstFlags.Has(ModifyTimeNow) {
+		timestamp := Timestamp(time.Now().UnixNano())
+		if fstFlags.Has(AccessTimeNow) {
+			accessTime = timestamp
+		}
+		if fstFlags.Has(ModifyTimeNow) {
+			modifyTime = timestamp
+		}
+	}
+	changeAccessTime := fstFlags.Has(AccessTime) || fstFlags.Has(AccessTimeNow)
+	changeModifyTime := fstFlags.Has(ModifyTime) || fstFlags.Has(ModifyTimeNow)
+	if !changeAccessTime && !changeModifyTime {
+		return ESUCCESS
+	}
+	if !changeAccessTime || !changeModifyTime {
+		stat, errno := d.file.PathFileStatGet(ctx, lookupFlags, path)
+		if errno != ESUCCESS {
+			return errno
+		}
+		if !changeAccessTime {
+			accessTime = stat.AccessTime
+		}
+		if !changeModifyTime {
+			modifyTime = stat.ModifyTime
+		}
+	}
+	return d.file.PathFileStatSetTimes(ctx, lookupFlags, path, accessTime, modifyTime)
+}
+
+func (t *FileTable[T]) PathLink(ctx context.Context, fd FD, flags LookupFlags, oldPath string, newFD FD, newPath string) Errno {
+	oldDir, errno := t.lookupFD(fd, PathLinkSourceRight)
+	if errno != ESUCCESS {
+		return errno
+	}
+	newDir, errno := t.lookupFD(newFD, PathLinkTargetRight)
+	if errno != ESUCCESS {
+		return errno
+	}
+	return oldDir.file.PathLink(ctx, flags, oldPath, newDir.file, newPath)
+}
+
+func (t *FileTable[T]) PathOpen(ctx context.Context, fd FD, lookupFlags LookupFlags, path string, openFlags OpenFlags, rightsBase, rightsInheriting Rights, fdFlags FDFlags) (FD, Errno) {
+	d, errno := t.lookupFD(fd, PathOpenRight)
+	if errno != ESUCCESS {
+		return -1, errno
+	}
+	clean := filepath.Clean(path)
+	if strings.HasPrefix(clean, "/") || strings.HasPrefix(clean, "../") {
+		return -1, EPERM
+	}
+
+	// Rights can only be preserved or removed, not added.
+	rightsBase &= AllRights
+	rightsInheriting &= AllRights
+	if (rightsBase &^ d.stat.RightsInheriting) != 0 {
+		return -1, ENOTCAPABLE
+	} else if (rightsInheriting &^ d.stat.RightsInheriting) != 0 {
+		return -1, ENOTCAPABLE
+	}
+	rightsBase &= d.stat.RightsInheriting
+	rightsInheriting &= d.stat.RightsInheriting
+
+	if openFlags.Has(OpenDirectory) {
+		rightsBase &= DirectoryRights
+	}
+	if openFlags.Has(OpenCreate) {
+		if !d.stat.RightsBase.Has(PathCreateFileRight) {
+			return -1, ENOTCAPABLE
+		}
+	}
+	if openFlags.Has(OpenTruncate) {
+		if !d.stat.RightsBase.Has(PathFileStatSetSizeRight) {
+			return -1, ENOTCAPABLE
+		}
+	}
+
+	newFile, errno := d.file.PathOpen(ctx, lookupFlags, path, openFlags, rightsBase, rightsInheriting, fdFlags)
+	if errno != ESUCCESS {
+		return -1, errno
+	}
+
+	fileType := RegularFileType
+	if openFlags.Has(OpenDirectory) {
+		fileType = DirectoryType
+	}
+
+	newFD := t.Register(newFile, FDStat{
+		FileType:         fileType,
+		Flags:            fdFlags,
+		RightsBase:       rightsBase,
+		RightsInheriting: rightsInheriting,
+	})
+	return newFD, ESUCCESS
+}
+
+func (t *FileTable[T]) PathReadLink(ctx context.Context, fd FD, path string, buffer []byte) (int, Errno) {
+	d, errno := t.lookupFD(fd, PathReadLinkRight)
+	if errno != ESUCCESS {
+		return 0, errno
+	}
+	return d.file.PathReadLink(ctx, path, buffer)
+}
+
+func (t *FileTable[T]) PathRemoveDirectory(ctx context.Context, fd FD, path string) Errno {
+	d, errno := t.lookupFD(fd, PathRemoveDirectoryRight)
+	if errno != ESUCCESS {
+		return errno
+	}
+	return d.file.PathRemoveDirectory(ctx, path)
+}
+
+func (t *FileTable[T]) PathRename(ctx context.Context, fd FD, oldPath string, newFD FD, newPath string) Errno {
+	oldDir, errno := t.lookupFD(fd, PathRenameSourceRight)
+	if errno != ESUCCESS {
+		return errno
+	}
+	newDir, errno := t.lookupFD(newFD, PathRenameTargetRight)
+	if errno != ESUCCESS {
+		return errno
+	}
+	return oldDir.file.PathRename(ctx, oldPath, newDir.file, newPath)
+}
+
+func (t *FileTable[T]) PathSymlink(ctx context.Context, oldPath string, fd FD, newPath string) Errno {
+	d, errno := t.lookupFD(fd, PathSymlinkRight)
+	if errno != ESUCCESS {
+		return errno
+	}
+	return d.file.PathSymlink(ctx, oldPath, newPath)
+}
+
+func (t *FileTable[T]) PathUnlinkFile(ctx context.Context, fd FD, path string) Errno {
+	d, errno := t.lookupFD(fd, PathUnlinkFileRight)
+	if errno != ESUCCESS {
+		return errno
+	}
+	return d.file.PathUnlinkFile(ctx, path)
+}
+
+// SizesGet is a helper function used to implement the ArgsSizesGet and
+// EnvironSizesGet methods of the System interface. Given a list of values
+// it returns the count and byte size of their representation in the ABI.
+func SizesGet(values []string) (count, size int) {
+	for _, value := range values {
+		size += len(value) + 1
+	}
+	return len(values), size
+}


### PR DESCRIPTION
I would like to suggest a refactor to extract the file tables and most of the generic logic out of `unix.System` and into a `wasi.FileTable[File]` type.

The decoupling of the file table operations, and actual invocation of operations on a file makes it possible to experiment with new implementations of `wasi.System` which are not wrappers but bottom layers (like `unix.System` but potentially having a different implementation). With this model, we can implement only the specialized parts. It accelerates our ability to create new systems and ensures that we minimize the risks of seeing divergence of behaviors.

Please take a look and let me know if you would like to see anything changed!