### PR TITLE
unix: fix SockConnect return addr

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -643,7 +643,9 @@ func (t *Tracer) SockConnect(ctx context.Context, fd FD, peer SocketAddress) (So
 	}
 	t.printf("SockConnect(%d, %s) => ", fd, peer)
 	addr, errno := s.SockConnect(ctx, fd, peer)
-	if errno == ESUCCESS {
+	if errno == EINPROGRESS {
+		t.printf("%s (EINPROGRESS)", addr)
+	} else if errno == ESUCCESS {
 		t.printf("%s", addr)
 	} else {
 		t.printErrno(errno)


### PR DESCRIPTION
In https://github.com/stealthrocket/wasi-go/pull/37, `SockConnect` was updated to return the local address that the connection was made from.

This PR fixes the unix implementation to do that, and to correctly handle `EINPROGRESS` errors.