### PR TITLE
wasmedge: fix v1 getlocaladdr/getpeeraddr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.20
 
 require (
 	github.com/stealthrocket/wazergo v0.17.1
-	github.com/tetratelabs/wazero v1.1.0
+	github.com/tetratelabs/wazero v1.2.0
 	golang.org/x/sys v0.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/stealthrocket/wazergo v0.17.1 h1:lXx4/Lg1A+9ATZWYI0J2E4oWfihhOLxWfnAT2Wy8iKQ=
 github.com/stealthrocket/wazergo v0.17.1/go.mod h1:riI0hxw4ndZA5e6z7PesHg2BtTftcZaMxRcoiGGipTs=
-github.com/tetratelabs/wazero v1.1.0 h1:EByoAhC+QcYpwSZJSs/aV0uokxPwBgKxfiokSUwAknQ=
-github.com/tetratelabs/wazero v1.1.0/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+github.com/tetratelabs/wazero v1.2.0 h1:I/8LMf4YkCZ3r2XaL9whhA0VMyAvF6QE+O7rco0DCeQ=
+github.com/tetratelabs/wazero v1.2.0/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/imports/wasi_snapshot_preview1/wasmedge.go
+++ b/imports/wasi_snapshot_preview1/wasmedge.go
@@ -209,11 +209,11 @@ func (m *Module) WasmEdgeV1SockLocalAddr(ctx context.Context, fd Int32, addr Poi
 	if errno != wasi.ESUCCESS {
 		return Errno(errno)
 	}
-	portint, pf, ok := m.wasmEdgeV1PutSocketAddress(addr.Load(), sa)
+	portint, at, ok := m.wasmEdgeV1PutSocketAddress(addr.Load(), sa)
 	if !ok {
 		return Errno(wasi.EINVAL)
 	}
-	addrType.Store(Uint32(pf))
+	addrType.Store(Uint32(at))
 	port.Store(Uint32(portint))
 	return Errno(wasi.ESUCCESS)
 }
@@ -244,11 +244,11 @@ func (m *Module) WasmEdgeV1SockPeerAddr(ctx context.Context, fd Int32, addr Poin
 	if errno != wasi.ESUCCESS {
 		return Errno(errno)
 	}
-	portint, pf, ok := m.wasmEdgeV1PutSocketAddress(addr.Load(), sa)
+	portint, at, ok := m.wasmEdgeV1PutSocketAddress(addr.Load(), sa)
 	if !ok {
 		return Errno(wasi.EINVAL)
 	}
-	addrType.Store(Uint32(pf))
+	addrType.Store(Uint32(at))
 	port.Store(Uint32(portint))
 	return Errno(wasi.ESUCCESS)
 }
@@ -300,7 +300,7 @@ func (m *Module) wasmEdgeGetSocketAddress(b wasmEdgeAddress, port int) (sa wasi.
 	return
 }
 
-func (m *Module) wasmEdgeV1PutSocketAddress(b wasmEdgeAddress, sa wasi.SocketAddress) (port int, pf wasi.ProtocolFamily, ok bool) {
+func (m *Module) wasmEdgeV1PutSocketAddress(b wasmEdgeAddress, sa wasi.SocketAddress) (port, addressType int, ok bool) {
 	if len(b) != 16 {
 		return
 	}
@@ -308,13 +308,13 @@ func (m *Module) wasmEdgeV1PutSocketAddress(b wasmEdgeAddress, sa wasi.SocketAdd
 	case *wasi.Inet4Address:
 		binary.LittleEndian.PutUint16(b, uint16(wasi.Inet))
 		copy(b, t.Addr[:])
-		pf = wasi.Inet
+		addressType = 4
 		port = t.Port
 		ok = true
 	case *wasi.Inet6Address:
 		binary.LittleEndian.PutUint16(b, uint16(wasi.Inet6))
 		copy(b, t.Addr[:])
-		pf = wasi.Inet6
+		addressType = 6
 		port = t.Port
 		ok = true
 	}


### PR DESCRIPTION
I incorrectly assumed that WasmEdge's v1 `sock_getlocaladdr` and `sock_getpeeraddr` functions would expect either `AF_INET` or `AF_INET6` for the address type. Instead, they expect either 4 or 6 ([reference](https://github.com/second-state/wasmedge_wasi_socket/blob/7e49c11063b0bee93f48a294122565dd2c9c8349/src/socket.rs#L851-L854)).

With this fix, we're able to run the WasmEdge HTTP server examples, e.g. https://github.com/WasmEdge/wasmedge_hyper_demo.