### PR TITLE
wasmedge: support sock_getaddrinfo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/stealthrocket/wasi-go
 go 1.20
 
 require (
-	github.com/stealthrocket/wazergo v0.17.1
+	github.com/stealthrocket/wazergo v0.19.1
 	github.com/tetratelabs/wazero v1.2.0
 	golang.org/x/sys v0.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/stealthrocket/wazergo v0.17.1 h1:lXx4/Lg1A+9ATZWYI0J2E4oWfihhOLxWfnAT2Wy8iKQ=
-github.com/stealthrocket/wazergo v0.17.1/go.mod h1:riI0hxw4ndZA5e6z7PesHg2BtTftcZaMxRcoiGGipTs=
+github.com/stealthrocket/wazergo v0.19.1 h1:BPrITETPgSFwiytwmToO0MbUC/+RGC39JScz1JmmG6c=
+github.com/stealthrocket/wazergo v0.19.1/go.mod h1:riI0hxw4ndZA5e6z7PesHg2BtTftcZaMxRcoiGGipTs=
 github.com/tetratelabs/wazero v1.2.0 h1:I/8LMf4YkCZ3r2XaL9whhA0VMyAvF6QE+O7rco0DCeQ=
 github.com/tetratelabs/wazero v1.2.0/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=

--- a/imports/wasi_snapshot_preview1/module.go
+++ b/imports/wasi_snapshot_preview1/module.go
@@ -135,6 +135,8 @@ type Module struct {
 	inet4addr wasi.Inet4Address
 	inet6addr wasi.Inet6Address
 	unixaddr  wasi.UnixAddress
+	addrhint  wasi.AddressInfo
+	addrinfo  []wasi.AddressInfo
 }
 
 func (m *Module) ArgsGet(ctx context.Context, argv Pointer[Uint32], buf Pointer[Uint8]) Errno {

--- a/imports/wasi_snapshot_preview1/module.go
+++ b/imports/wasi_snapshot_preview1/module.go
@@ -135,7 +135,6 @@ type Module struct {
 	inet4addr wasi.Inet4Address
 	inet6addr wasi.Inet6Address
 	unixaddr  wasi.UnixAddress
-	addrhint  wasi.AddressInfo
 	addrinfo  []wasi.AddressInfo
 }
 

--- a/imports/wasi_snapshot_preview1/wasmedge.go
+++ b/imports/wasi_snapshot_preview1/wasmedge.go
@@ -325,6 +325,7 @@ func (m *Module) WasmEdgeSockAddrInfo(ctx context.Context, name String, service 
 		if res.Address == 0 {
 			return Errno(wasi.EFAULT)
 		}
+		res.AddressLength = 16 // sizeof(WasiSockaddr)
 		addrDataFamily, ok := mem.Read(res.Address, 1)
 		if !ok {
 			return Errno(wasi.EFAULT)
@@ -353,6 +354,7 @@ func (m *Module) WasmEdgeSockAddrInfo(ctx context.Context, name String, service 
 			binary.BigEndian.PutUint16(addrData, uint16(addr.Port))
 			copy(addrData[2:], addr.Addr[:])
 			addrDataFamily[0] = uint8(wasi.InetFamily)
+			// mem.WriteUint32Le(res.Address+4, 6) // WasmEdge writes 16?
 		case *wasi.Inet6Address:
 			if len(addrData) < 18 {
 				return Errno(wasi.EFAULT)
@@ -360,6 +362,7 @@ func (m *Module) WasmEdgeSockAddrInfo(ctx context.Context, name String, service 
 			binary.BigEndian.PutUint16(addrData, uint16(addr.Port))
 			copy(addrData[2:], addr.Addr[:])
 			addrDataFamily[0] = uint8(wasi.Inet6Family)
+			// mem.WriteUint32Le(res.Address+4, 18) // WasmEdge writes 26?
 		}
 		res.CanonicalNameLength = 0 // Not yet supported
 		resPtr.Store(res)

--- a/imports/wasi_snapshot_preview1/wasmedge.go
+++ b/imports/wasi_snapshot_preview1/wasmedge.go
@@ -289,7 +289,10 @@ func (m *Module) WasmEdgeSockAddrInfo(ctx context.Context, node String, service 
 		hints.SocketType = wasi.SocketType(rawhints.SocketType)
 		hints.Protocol = wasi.Protocol(rawhints.Protocol)
 	}
-	n, errno := s.SockAddressInfo(ctx, string(node), string(service), hints, m.addrinfo[:0])
+	if int(maxResLength) > cap(m.addrinfo) {
+		m.addrinfo = make([]wasi.AddressInfo, int(maxResLength))
+	}
+	n, errno := s.SockAddressInfo(ctx, string(node), string(service), hints, m.addrinfo[:maxResLength])
 	if errno != wasi.ESUCCESS {
 		return Errno(errno)
 	}

--- a/sockets_extension.go
+++ b/sockets_extension.go
@@ -94,7 +94,7 @@ type SocketsExtension interface {
 	// interface. Assume that any method may invalidate the addresses.
 	//
 	// Note: This is similar to getaddrinfo in POSIX.
-	SockAddressInfo(ctx context.Context, name, service string, hint AddressInfo, results []AddressInfo) (int, Errno)
+	SockAddressInfo(ctx context.Context, name, service string, hints AddressInfo, results []AddressInfo) (int, Errno)
 }
 
 // Port is a port.

--- a/systems/unix/system.go
+++ b/systems/unix/system.go
@@ -700,6 +700,10 @@ func (s *System) SockRemoteAddress(ctx context.Context, fd wasi.FD) (wasi.Socket
 	return addr, wasi.ESUCCESS
 }
 
+func (s *System) SockAddressInfo(ctx context.Context, node, service string, hint *wasi.AddressInfo, results []wasi.AddressInfo) (int, wasi.Errno) {
+	panic("not implemented")
+}
+
 func (s *System) Close(ctx context.Context) error {
 	err := s.FileTable.Close(ctx)
 

--- a/tracer.go
+++ b/tracer.go
@@ -754,15 +754,15 @@ func (t *Tracer) SockRemoteAddress(ctx context.Context, fd FD) (SocketAddress, E
 	return addr, errno
 }
 
-func (t *Tracer) SockAddressInfo(ctx context.Context, name, service string, hint AddressInfo, results []AddressInfo) (int, Errno) {
+func (t *Tracer) SockAddressInfo(ctx context.Context, name, service string, hints AddressInfo, results []AddressInfo) (int, Errno) {
 	s, ok := t.System.(SocketsExtension)
 	if !ok {
 		return 0, ENOSYS
 	}
 	t.printf("SockAddressInfo(%s, %s, ", name, service)
-	t.printAddressInfo(hint)
+	t.printAddressInfo(hints)
 	t.printf(", [%d]AddressInfo) => ", len(results))
-	n, errno := s.SockAddressInfo(ctx, name, service, hint, results)
+	n, errno := s.SockAddressInfo(ctx, name, service, hints, results)
 	if errno == ESUCCESS {
 		t.printf("[")
 		for i := range results[:n] {

--- a/tracer.go
+++ b/tracer.go
@@ -765,7 +765,7 @@ func (t *Tracer) SockAddressInfo(ctx context.Context, node, service string, hint
 	} else {
 		t.printf("hint=nil")
 	}
-	t.printf(") => ")
+	t.printf(", [%d]AddressInfo) => ", len(results))
 	n, errno := s.SockAddressInfo(ctx, node, service, hint, results)
 	if errno == ESUCCESS {
 		t.printf("[")

--- a/tracer.go
+++ b/tracer.go
@@ -754,26 +754,22 @@ func (t *Tracer) SockRemoteAddress(ctx context.Context, fd FD) (SocketAddress, E
 	return addr, errno
 }
 
-func (t *Tracer) SockAddressInfo(ctx context.Context, node, service string, hint *AddressInfo, results []AddressInfo) (int, Errno) {
+func (t *Tracer) SockAddressInfo(ctx context.Context, name, service string, hint AddressInfo, results []AddressInfo) (int, Errno) {
 	s, ok := t.System.(SocketsExtension)
 	if !ok {
 		return 0, ENOSYS
 	}
-	t.printf("SockAddressInfo(%s, %s, ", node, service)
-	if hint != nil {
-		t.printAddressInfo(hint)
-	} else {
-		t.printf("hint=nil")
-	}
+	t.printf("SockAddressInfo(%s, %s, ", name, service)
+	t.printAddressInfo(hint)
 	t.printf(", [%d]AddressInfo) => ", len(results))
-	n, errno := s.SockAddressInfo(ctx, node, service, hint, results)
+	n, errno := s.SockAddressInfo(ctx, name, service, hint, results)
 	if errno == ESUCCESS {
 		t.printf("[")
 		for i := range results[:n] {
 			if i > 0 {
 				t.printf(", ")
 			}
-			t.printAddressInfo(&results[i])
+			t.printAddressInfo(results[i])
 		}
 		t.printf("]")
 	} else {
@@ -895,7 +891,7 @@ func (t *Tracer) printDirEntries(dirEntries []DirEntry, bufferSizeBytes int) {
 	t.printf("}")
 }
 
-func (t *Tracer) printAddressInfo(a *AddressInfo) {
+func (t *Tracer) printAddressInfo(a AddressInfo) {
 	t.printf("{")
 	if a.Flags != 0 {
 		t.printf("Flags:%s,", a.Flags)


### PR DESCRIPTION
This PR implements the `sock_getaddrinfo` host function from WasmEdge.

I chose not to use `getaddrinfo(3)` directly, to avoid CGO, but also because I'd need different implementations for Linux and macOS. Rather, I'm using `net.LookupIP` and `net.LookupPort` to implement a subset of the functionality offered by `getaddrinfo(3)`.

Reference:
* https://github.com/WasmEdge/WasmEdge/blob/d2fc0ffc/thirdparty/wasi/api.hpp
* https://github.com/WasmEdge/WasmEdge/blob/d2fc0ffc/lib/host/wasi/wasifunc.cpp#L2132
* https://github.com/WasmEdge/WasmEdge/blob/d2fc0ffc/lib/host/wasi/inode-linux.cpp#L796
* https://github.com/second-state/wasmedge_wasi_socket/blob/7e49c110/src/socket.rs#L138
* https://github.com/second-state/wasmedge_wasi_socket/blob/7e49c110/src/lib.rs#L322

## Example

_Cargo.toml_

```toml
[package]
name = "nslookup"
version = "0.0.1"
edition = "2021"

[dependencies]
wasmedge_wasi_socket = { version = "0.5.0", default-features = false, features = ["wasmedge_0_12"] }
```

_src/main.rs_

```rust
use wasmedge_wasi_socket::nslookup;

fn main() {
    let addrs = nslookup("google.com", "http").unwrap();
    for addr in addrs {
        println!("{:?}",addr);
    }
}
```

Example:

```
$ cargo build --target wasm32-wasi
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
$ wasmedge ./target/wasm32-wasi/debug/nslookup.wasm 
172.217.24.46:80
$ wasirun ./target/wasm32-wasi/debug/nslookup.wasm 
172.217.24.46:80
$ wasirun --trace ./target/wasm32-wasi/debug/nslookup.wasm >/dev/null
SockAddressInfo(google.com, http, {Family:InetFamily,SocketType:StreamSocket,Protocol:TCPProtocol}, [10]AddressInfo) => [{Family:UnspecifiedFamily,SocketType:AnySocket,Protocol:IPProtocol,Address:172.217.24.46:80}]
FDWrite(1, [1]IOVec{[17]byte("172.217.24.46:80\n")}) => 17
Close() => ok
```