### PR TITLE
wasi: fix closing of file descriptors

### DIFF
--- a/error.go
+++ b/error.go
@@ -145,6 +145,7 @@ const (
 
 	// ENOENT means no such file or directory.
 	ENOENT
+
 	// ENOEXEC means an exec format error.
 	ENOEXEC
 

--- a/imports/builder.go
+++ b/imports/builder.go
@@ -116,9 +116,9 @@ func (b *Builder) WithDials(dials ...string) *Builder {
 
 // WithStdio sets stdio file descriptors.
 //
-// Note that the file descriptors will be duplicated before the module takes
-// ownership. The caller is responsible for managing the specified
-// descriptors.
+// Note that the builder takes ownership of the file descriptors, it might
+// change their state such as making them non-blocking and will close them
+// when they are not needed anymore.
 func (b *Builder) WithStdio(stdin, stdout, stderr int) *Builder {
 	b.customStdio = true
 	b.stdin = stdin

--- a/imports/builder.go
+++ b/imports/builder.go
@@ -116,9 +116,9 @@ func (b *Builder) WithDials(dials ...string) *Builder {
 
 // WithStdio sets stdio file descriptors.
 //
-// Note that the builder takes ownership of the file descriptors, it might
-// change their state such as making them non-blocking and will close them
-// when they are not needed anymore.
+// Note that the file descriptors will be duplicated before the module takes
+// ownership. The caller is responsible for managing the specified
+// descriptors.
 func (b *Builder) WithStdio(stdin, stdout, stderr int) *Builder {
 	b.customStdio = true
 	b.stdin = stdin

--- a/imports/builder_unix.go
+++ b/imports/builder_unix.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"syscall"
 
 	"github.com/stealthrocket/wasi-go"
@@ -113,7 +114,7 @@ func (b *Builder) Instantiate(ctx context.Context, runtime wazero.Runtime) (ctxr
 			stdio.fd, err = dup(stdio.fd)
 		}
 		if err != nil {
-			return ctx, nil, fmt.Errorf("unable to duplicate %s fd %d: %w", stdio.path, stdio.fd, err)
+			return ctx, nil, fmt.Errorf("unable to create %s: %w", strings.TrimPrefix("/dev/", stdio.path), err)
 		}
 		rights := wasi.FileRights
 		if descriptor.IsATTY(stdio.fd) {

--- a/imports/builder_unix.go
+++ b/imports/builder_unix.go
@@ -29,11 +29,9 @@ func (b *Builder) Instantiate(ctx context.Context, runtime wazero.Runtime) (ctxr
 		name = b.name
 	}
 
-	stdin, stdout, stderr := b.stdin, b.stdout, b.stderr
-	if !b.customStdio {
-		stdin = syscall.Stdin
-		stdout = syscall.Stdout
-		stderr = syscall.Stderr
+	stdin, stdout, stderr := -1, -1, -1
+	if b.customStdio {
+		stdin, stdout, stderr = b.stdin, b.stdout, b.stderr
 	}
 
 	realtime := defaultRealtime
@@ -101,12 +99,20 @@ func (b *Builder) Instantiate(ctx context.Context, runtime wazero.Runtime) (ctxr
 
 	for _, stdio := range []struct {
 		fd   int
+		open int
 		path string
 	}{
-		{stdin, "/dev/stdin"},
-		{stdout, "/dev/stdout"},
-		{stderr, "/dev/stderr"},
+		{stdin, syscall.O_RDONLY, "/dev/stdin"},
+		{stdout, syscall.O_WRONLY, "/dev/stdout"},
+		{stderr, syscall.O_WRONLY, "/dev/stderr"},
 	} {
+		var err error
+		if stdio.fd < 0 {
+			stdio.fd, err = syscall.Open(stdio.path, stdio.open, 0)
+		}
+		if err != nil {
+			return ctx, nil, fmt.Errorf("unable to duplicate %s fd %d: %w", stdio.path, stdio.fd, err)
+		}
 		rights := wasi.FileRights
 		if descriptor.IsATTY(stdio.fd) {
 			rights = wasi.TTYRights
@@ -115,17 +121,13 @@ func (b *Builder) Instantiate(ctx context.Context, runtime wazero.Runtime) (ctxr
 			FileType:   wasi.CharacterDeviceType,
 			RightsBase: rights,
 		}
-		newfd, err := dup(stdio.fd)
-		if err != nil {
-			return ctx, nil, fmt.Errorf("unable to duplicate %s fd %d: %w", stdio.path, stdio.fd, err)
-		}
 		if b.nonBlockingStdio {
-			if err := syscall.SetNonblock(newfd, true); err != nil {
+			if err := syscall.SetNonblock(stdio.fd, true); err != nil {
 				return ctx, nil, fmt.Errorf("unable to put %s in non-blocking mode: %w", stdio.path, err)
 			}
 			stat.Flags |= wasi.NonBlock
 		}
-		unixSystem.Preopen(unix.FD(newfd), stdio.path, stat)
+		unixSystem.Preopen(unix.FD(stdio.fd), stdio.path, stat)
 	}
 
 	for _, m := range b.mounts {
@@ -183,18 +185,5 @@ func (b *Builder) Instantiate(ctx context.Context, runtime wazero.Runtime) (ctxr
 	)
 
 	ctx = wazergo.WithModuleInstance(ctx, instance)
-
 	return ctx, system, nil
-}
-
-func dup(fd int) (int, error) {
-	syscall.ForkLock.Lock()
-	defer syscall.ForkLock.Unlock()
-
-	newfd, err := syscall.Dup(fd)
-	if err != nil {
-		return -1, err
-	}
-	syscall.CloseOnExec(newfd)
-	return newfd, nil
 }

--- a/internal/sockets/dial.go
+++ b/internal/sockets/dial.go
@@ -13,17 +13,17 @@ func Dial(rawAddr string) (int, error) {
 	opt := addr.Query()
 	noDelay := intopt(opt, "nodelay", 1)
 	if err = syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, syscall.TCP_NODELAY, noDelay); err != nil {
-		syscall.Close(fd)
+		Close(fd)
 		return -1, err
 	}
 	nonBlock := boolopt(opt, "nonblock", true)
 	if err := syscall.SetNonblock(fd, nonBlock); err != nil {
-		syscall.Close(fd)
+		Close(fd)
 		return -1, err
 	}
 	err = syscall.Connect(fd, sa)
 	if err != nil && err != EINPROGRESS {
-		syscall.Close(fd)
+		Close(fd)
 		return -1, err
 	}
 	return fd, err

--- a/internal/sockets/listen.go
+++ b/internal/sockets/listen.go
@@ -11,21 +11,21 @@ func Listen(rawAddr string) (int, error) {
 	opt := addr.Query()
 	reuseAddr := intopt(opt, "reuseaddr", 1)
 	if err = syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, reuseAddr); err != nil {
-		syscall.Close(fd)
+		Close(fd)
 		return -1, err
 	}
 	if err := syscall.Bind(fd, sa); err != nil {
-		syscall.Close(fd)
+		Close(fd)
 		return -1, err
 	}
 	nonBlock := boolopt(opt, "nonblock", true)
 	if err := syscall.SetNonblock(fd, nonBlock); err != nil {
-		syscall.Close(fd)
+		Close(fd)
 		return -1, err
 	}
 	backlog := intopt(opt, "backlog", 128)
 	if err := syscall.Listen(fd, backlog); err != nil {
-		syscall.Close(fd)
+		Close(fd)
 		return -1, err
 	}
 	return fd, nil

--- a/internal/sockets/socket.go
+++ b/internal/sockets/socket.go
@@ -29,7 +29,7 @@ func Socket(rawAddr string) (u *url.URL, sa syscall.Sockaddr, fd int, err error)
 	}
 	defer func() {
 		if err != nil {
-			syscall.Close(fd)
+			Close(fd)
 			fd = -1
 		}
 	}()

--- a/systems/unix/syscall_darwin.go
+++ b/systems/unix/syscall_darwin.go
@@ -68,6 +68,8 @@ func pipeCloseOnExec(fds []int) error {
 func closePipe(fds []int) {
 	unix.Close(fds[1])
 	unix.Close(fds[0])
+	fds[0] = -1
+	fds[1] = -1
 }
 
 const (

--- a/tracer.go
+++ b/tracer.go
@@ -791,7 +791,7 @@ func (t *Tracer) printSubscription(s Subscription) {
 func (t *Tracer) printEvent(e Event) {
 	t.printf("{EventType:%s,UserData:%#x", e.EventType, e.UserData)
 	if e.Errno != 0 {
-		t.printf(",Errno:%s", e.Errno.Name())
+		t.printf(",Errno:%s}", e.Errno.Name())
 	}
 	if e.EventType != ClockEvent {
 		fdrw := e.FDReadWrite

--- a/wasi.go
+++ b/wasi.go
@@ -218,6 +218,9 @@ func (t *FileTable[T]) FDClose(ctx context.Context, fd FD) Errno {
 	if errno != ESUCCESS {
 		return errno
 	}
+	// We capture the file before removing the table entry because f is a
+	// pointer into the table and gets erased when the descriptor is deleted.
+	file := f.file
 	t.files.Delete(fd)
 	// Note: closing pre-opens is allowed.
 	// See github.com/WebAssembly/wasi-testsuite/blob/1b1d4a5/tests/rust/src/bin/close_preopen.rs
@@ -226,7 +229,7 @@ func (t *FileTable[T]) FDClose(ctx context.Context, fd FD) Errno {
 		delete(t.dirs, fd)
 		dir.FDCloseDir(ctx)
 	}
-	return f.file.FDClose(ctx)
+	return file.FDClose(ctx)
 }
 
 func (t *FileTable[T]) FDDataSync(ctx context.Context, fd FD) Errno {


### PR DESCRIPTION
This PR addresses a bug that was causing the host fd 0 to be closed unexpectedly when any guest file descriptors were closed.

The bug was introduced by the refactor in #38 
