### PR TITLE
WASIX sockets

### DIFF
--- a/cmd/wasirun/main.go
+++ b/cmd/wasirun/main.go
@@ -44,7 +44,7 @@ OPTIONS:
 
    --sockets <NAME>
       Enable a sockets extension, either {none, auto, path_open,
-      wasmedgev1, wasmedgev2}
+      wasmedgev1, wasmedgev2, wasix}
 
    --pprof-addr <ADDR>
       Start a pprof server listening on the specified address

--- a/imports/builder.go
+++ b/imports/builder.go
@@ -165,6 +165,7 @@ func (b *Builder) WithRaise(fn func(context.Context, int) error) *Builder {
 // - none: disable sockets extensions (use vanilla WASI preview 1)
 // - wasmedgev1: use WasmEdge sockets extension version 1
 // - wasmedgev2: use WasmEdge sockets extension version 2
+// - wasix: use the WASIX sockets extension
 // - path_open: use the extension to the path_open system call (unix.PathOpenSockets)
 // - auto: attempt to detect one of the extensions above
 func (b *Builder) WithSocketsExtension(name string, module wazero.CompiledModule) *Builder {
@@ -175,6 +176,8 @@ func (b *Builder) WithSocketsExtension(name string, module wazero.CompiledModule
 		b.socketsExtension = &wasi_snapshot_preview1.WasmEdgeV1
 	case "wasmedgev2":
 		b.socketsExtension = &wasi_snapshot_preview1.WasmEdgeV2
+	case "wasix":
+		b.socketsExtension = &wasi_snapshot_preview1.Wasix
 	case "path_open":
 		b.socketsExtension = nil
 		b.pathOpenSockets = true

--- a/imports/wasi_snapshot_preview1/wasix.go
+++ b/imports/wasi_snapshot_preview1/wasix.go
@@ -1,0 +1,51 @@
+package wasi_snapshot_preview1
+
+import (
+	"context"
+
+	"github.com/stealthrocket/wasi-go"
+	"github.com/stealthrocket/wazergo"
+)
+
+var Wasix = Extension{
+	"sock_status":             wazergo.F2((*Module).WasixSockStatus),
+	"sock_addr_local":         wazergo.F2((*Module).WasixSockAddrLocal),
+	"sock_addr_peer":          wazergo.F2((*Module).WasixSockAddrPeer),
+	"sock_open":               wazergo.F4((*Module).WasixSockOpen),
+	"sock_set_opt_flag":       wazergo.F3((*Module).WasixSockSetOptFlag),
+	"sock_get_opt_flag":       wazergo.F3((*Module).WasixSockGetOptFlag),
+	"sock_set_opt_time":       wazergo.F3((*Module).WasixSockSetOptTime),
+	"sock_get_opt_time":       wazergo.F3((*Module).WasixSockGetOptTime),
+	"sock_set_opt_size":       wazergo.F3((*Module).WasixSockSetOptSize),
+	"sock_get_opt_size":       wazergo.F3((*Module).WasixSockGetOptSize),
+	"sock_join_multicast_v4":  wazergo.F3((*Module).WasixSockJoinMulticastV4),
+	"sock_leave_multicast_v4": wazergo.F3((*Module).WasixSockLeaveMulticastV4),
+	"sock_join_multicast_v6":  wazergo.F3((*Module).WasixSockJoinMulticastV6),
+	"sock_leave_multicast_v6": wazergo.F3((*Module).WasixSockLeaveMulticastV6),
+	"sock_bind":               wazergo.F2((*Module).WasixSockBind),
+	"sock_listen":             wazergo.F2((*Module).WasixSockListen),
+	"sock_accept_v2":          wazergo.F4((*Module).WasixSockAcceptV2),
+	"sock_connect":            wazergo.F2((*Module).WasixSockConnect),
+	"sock_recv_from":          wazergo.F7((*Module).WasixSockRecvFrom),
+	"sock_send_to":            wazergo.F6((*Module).WasixSockSendTo),
+	"sock_send_file":          wazergo.F5((*Module).WasixSockSendFile),
+	"resolve":                 wazergo.F6((*Module).WasixResolve),
+}
+
+func (m *Module) WasixSockStatus(ctx context.Context, fd Int32, sockStatus Pointer[Uint8]) errno {
+	return Errno(wasi.ENOSYS)
+}
+
+func (m *Module) WasixSockAddrLocal(ctx context.Context, fd Int32, addrPort Pointer[wasixAddrPort]) errno {
+	return Errno(wasi.ENOSYS)
+}
+
+func (m *Module) WasixSockAddrPeer(ctx context.Context, fd Int32, addrPort Pointer[wasixAddrPort]) errno {
+	return Errno(wasi.ENOSYS)
+}
+
+func (m *Module) WasixSockOpen(ctx context.Context, family Int32, sockType Int32, protocol Int32, fd Pointer[Int32]) errno {
+	return Errno(wasi.ENOSYS)
+}
+
+type wasixAddrPort []byte

--- a/imports/wasi_snapshot_preview1/wasix.go
+++ b/imports/wasi_snapshot_preview1/wasix.go
@@ -2,50 +2,285 @@ package wasi_snapshot_preview1
 
 import (
 	"context"
+	"encoding/binary"
+	"io"
 
 	"github.com/stealthrocket/wasi-go"
 	"github.com/stealthrocket/wazergo"
+	. "github.com/stealthrocket/wazergo/types"
+	"github.com/tetratelabs/wazero/api"
 )
 
 var Wasix = Extension{
-	"sock_status":             wazergo.F2((*Module).WasixSockStatus),
-	"sock_addr_local":         wazergo.F2((*Module).WasixSockAddrLocal),
-	"sock_addr_peer":          wazergo.F2((*Module).WasixSockAddrPeer),
-	"sock_open":               wazergo.F4((*Module).WasixSockOpen),
-	"sock_set_opt_flag":       wazergo.F3((*Module).WasixSockSetOptFlag),
-	"sock_get_opt_flag":       wazergo.F3((*Module).WasixSockGetOptFlag),
-	"sock_set_opt_time":       wazergo.F3((*Module).WasixSockSetOptTime),
-	"sock_get_opt_time":       wazergo.F3((*Module).WasixSockGetOptTime),
-	"sock_set_opt_size":       wazergo.F3((*Module).WasixSockSetOptSize),
-	"sock_get_opt_size":       wazergo.F3((*Module).WasixSockGetOptSize),
-	"sock_join_multicast_v4":  wazergo.F3((*Module).WasixSockJoinMulticastV4),
-	"sock_leave_multicast_v4": wazergo.F3((*Module).WasixSockLeaveMulticastV4),
-	"sock_join_multicast_v6":  wazergo.F3((*Module).WasixSockJoinMulticastV6),
-	"sock_leave_multicast_v6": wazergo.F3((*Module).WasixSockLeaveMulticastV6),
-	"sock_bind":               wazergo.F2((*Module).WasixSockBind),
-	"sock_listen":             wazergo.F2((*Module).WasixSockListen),
-	"sock_accept_v2":          wazergo.F4((*Module).WasixSockAcceptV2),
-	"sock_connect":            wazergo.F2((*Module).WasixSockConnect),
-	"sock_recv_from":          wazergo.F7((*Module).WasixSockRecvFrom),
-	"sock_send_to":            wazergo.F6((*Module).WasixSockSendTo),
-	"sock_send_file":          wazergo.F5((*Module).WasixSockSendFile),
-	"resolve":                 wazergo.F6((*Module).WasixResolve),
+	"sock_status":       wazergo.F2((*Module).WasixSockStatus),
+	"sock_addr_local":   wazergo.F2((*Module).WasixSockAddrLocal),
+	"sock_addr_peer":    wazergo.F2((*Module).WasixSockAddrPeer),
+	"sock_open":         wazergo.F4((*Module).WasixSockOpen),
+	"sock_set_opt_flag": wazergo.F3((*Module).WasixSockSetOptFlag),
+	"sock_get_opt_flag": wazergo.F3((*Module).WasixSockGetOptFlag),
+	"sock_set_opt_time": wazergo.F3((*Module).WasixSockSetOptTime),
+	"sock_get_opt_time": wazergo.F3((*Module).WasixSockGetOptTime),
+	"sock_set_opt_size": wazergo.F3((*Module).WasixSockSetOptSize),
+	"sock_get_opt_size": wazergo.F3((*Module).WasixSockGetOptSize),
+	//"sock_join_multicast_v4":  wazergo.F3((*Module).WasixSockJoinMulticastV4),
+	//"sock_leave_multicast_v4": wazergo.F3((*Module).WasixSockLeaveMulticastV4),
+	//"sock_join_multicast_v6":  wazergo.F3((*Module).WasixSockJoinMulticastV6),
+	//"sock_leave_multicast_v6": wazergo.F3((*Module).WasixSockLeaveMulticastV6),
+	"sock_bind":      wazergo.F2((*Module).WasixSockBind),
+	"sock_listen":    wazergo.F2((*Module).WasixSockListen),
+	"sock_accept_v2": wazergo.F4((*Module).WasixSockAcceptV2),
+	"sock_connect":   wazergo.F2((*Module).WasixSockConnect),
+	"sock_recv_from": wazergo.F6((*Module).WasixSockRecvFrom),
+	"sock_send_to":   wazergo.F5((*Module).WasixSockSendTo),
+	"sock_send_file": wazergo.F5((*Module).WasixSockSendFile),
+	//"resolve":        wazergo.F6((*Module).WasixResolve),
 }
 
-func (m *Module) WasixSockStatus(ctx context.Context, fd Int32, sockStatus Pointer[Uint8]) errno {
+func (m *Module) WasixSockStatus(ctx context.Context, fd Int32, sockStatus Pointer[Uint8]) Errno {
 	return Errno(wasi.ENOSYS)
 }
 
-func (m *Module) WasixSockAddrLocal(ctx context.Context, fd Int32, addrPort Pointer[wasixAddrPort]) errno {
+func (m *Module) WasixSockAddrLocal(ctx context.Context, fd Int32, addrPort Pointer[wasixAddrPort]) Errno {
+	s, ok := m.WASI.(wasi.SocketsExtension)
+	if !ok {
+		return Errno(wasi.ENOSYS)
+	}
+	sa, errno := s.SockLocalAddress(ctx, wasi.FD(fd))
+	if errno != wasi.ESUCCESS {
+		return Errno(errno)
+	}
+	m.wasixPutAddrPort(addrPort.Load(), sa)
+	return Errno(wasi.ESUCCESS)
+}
+
+func (m *Module) WasixSockAddrPeer(ctx context.Context, fd Int32, addrPort Pointer[wasixAddrPort]) Errno {
+	s, ok := m.WASI.(wasi.SocketsExtension)
+	if !ok {
+		return Errno(wasi.ENOSYS)
+	}
+	sa, errno := s.SockRemoteAddress(ctx, wasi.FD(fd))
+	if errno != wasi.ESUCCESS {
+		return Errno(errno)
+	}
+	m.wasixPutAddrPort(addrPort.Load(), sa)
+	return Errno(wasi.ESUCCESS)
+}
+
+func (m *Module) WasixSockOpen(ctx context.Context, family Int32, sockType Int32, protocol Int32, openfd Pointer[Int32]) Errno {
+	s, ok := m.WASI.(wasi.SocketsExtension)
+	if !ok {
+		return Errno(wasi.ENOSYS)
+	}
+	rightsBase := wasi.SockListenRights | wasi.SockConnectionRights
+	rightsInheriting := wasi.SockConnectionRights
+	result, errno := s.SockOpen(ctx, wasi.ProtocolFamily(family), wasi.SocketType(sockType), wasi.Protocol(protocol), rightsBase, rightsInheriting)
+	if errno != wasi.ESUCCESS {
+		return Errno(errno)
+	}
+	openfd.Store(Int32(result))
+	return Errno(wasi.ESUCCESS)
+}
+
+func (m *Module) WasixSockSetOptFlag(ctx context.Context, fd Int32, opt Int32, flag Uint32) Errno {
 	return Errno(wasi.ENOSYS)
 }
 
-func (m *Module) WasixSockAddrPeer(ctx context.Context, fd Int32, addrPort Pointer[wasixAddrPort]) errno {
+func (m *Module) WasixSockGetOptFlag(ctx context.Context, fd Int32, opt Int32, value Pointer[Int32]) Errno {
 	return Errno(wasi.ENOSYS)
 }
 
-func (m *Module) WasixSockOpen(ctx context.Context, family Int32, sockType Int32, protocol Int32, fd Pointer[Int32]) errno {
+func (m *Module) WasixSockSetOptTime(ctx context.Context, fd Int32, opt Int32, timeout Pointer[wasixOptionTimestamp]) Errno {
 	return Errno(wasi.ENOSYS)
 }
 
+func (m *Module) WasixSockGetOptTime(ctx context.Context, fd Int32, opt Int32, timeout Pointer[wasixOptionTimestamp]) Errno {
+	return Errno(wasi.ENOSYS)
+}
+
+func (m *Module) WasixSockSetOptSize(ctx context.Context, fd Int32, opt Int32, size Uint64) Errno {
+	return Errno(wasi.ENOSYS)
+}
+
+func (m *Module) WasixSockGetOptSize(ctx context.Context, fd Int32, opt Int32, size Pointer[Uint64]) Errno {
+	return Errno(wasi.ENOSYS)
+}
+
+func (m *Module) WasixSockBind(ctx context.Context, fd Int32, addr Pointer[wasixAddrPort]) Errno {
+	s, ok := m.WASI.(wasi.SocketsExtension)
+	if !ok {
+		return Errno(wasi.ENOSYS)
+	}
+	socketAddr, ok := m.wasixGetAddrPort(addr.Load())
+	if !ok {
+		return Errno(wasi.EINVAL)
+	}
+	_, errno := s.SockBind(ctx, wasi.FD(fd), socketAddr)
+	return Errno(errno)
+}
+
+func (m *Module) WasixSockListen(ctx context.Context, fd Int32, backlog Int32) Errno {
+	s, ok := m.WASI.(wasi.SocketsExtension)
+	if !ok {
+		return Errno(wasi.ENOSYS)
+	}
+	return Errno(s.SockListen(ctx, wasi.FD(fd), int(backlog)))
+}
+
+func (m *Module) WasixSockAcceptV2(ctx context.Context, fd Int32, flags Int32, roFd Pointer[Int32], roAddr Pointer[wasixAddrPort]) Errno {
+	result, _, addr, errno := m.WASI.SockAccept(ctx, wasi.FD(fd), wasi.FDFlags(flags))
+	if errno != wasi.ESUCCESS {
+		return Errno(errno)
+	}
+	roFd.Store(Int32(result))
+	if ok := m.wasixPutAddrPort(roAddr.Load(), addr); !ok {
+		return Errno(wasi.EINVAL)
+	}
+	return Errno(errno)
+}
+
+func (m *Module) WasixSockConnect(ctx context.Context, fd Int32, addr Pointer[wasixAddrPort]) Errno {
+	s, ok := m.WASI.(wasi.SocketsExtension)
+	if !ok {
+		return Errno(wasi.ENOSYS)
+	}
+	socketAddr, ok := m.wasixGetAddrPort(addr.Load())
+	if !ok {
+		return Errno(wasi.EINVAL)
+	}
+	_, errno := s.SockConnect(ctx, wasi.FD(fd), socketAddr)
+	return Errno(errno)
+}
+
+func (m *Module) WasixSockRecvFrom(ctx context.Context, fd Int32, iovecs List[wasi.IOVec], iflags Int32, odatalen Pointer[Uint32], oflags Pointer[Int32], oaddr Pointer[wasixAddrPort]) Errno {
+	s, ok := m.WASI.(wasi.SocketsExtension)
+	if !ok {
+		return Errno(wasi.ENOSYS)
+	}
+	m.iovecs = iovecs.Append(m.iovecs[:0])
+	size, roflags, sa, errno := s.SockRecvFrom(ctx, wasi.FD(fd), m.iovecs, wasi.RIFlags(iflags))
+	if errno != wasi.ESUCCESS {
+		return Errno(errno)
+	}
+	if ok := m.wasixPutAddrPort(oaddr.Load(), sa); !ok {
+		return Errno(wasi.EINVAL)
+	}
+	odatalen.Store(Uint32(size))
+	oflags.Store(Int32(roflags))
+	return Errno(wasi.ESUCCESS)
+}
+
+func (m *Module) WasixSockSendTo(ctx context.Context, fd Int32, iovecs List[wasi.IOVec], iflags Int32, addr Pointer[wasixAddrPort], nwritten Pointer[Int32]) Errno {
+	s, ok := m.WASI.(wasi.SocketsExtension)
+	if !ok {
+		return Errno(wasi.ENOSYS)
+	}
+	socketAddr, ok := m.wasixGetAddrPort(addr.Load())
+	if !ok {
+		return Errno(wasi.EINVAL)
+	}
+	m.iovecs = iovecs.Append(m.iovecs[:0])
+	size, errno := s.SockSendTo(ctx, wasi.FD(fd), m.iovecs, wasi.SIFlags(iflags), socketAddr)
+	if errno != wasi.ESUCCESS {
+		return Errno(errno)
+	}
+	nwritten.Store(Int32(size))
+	return Errno(wasi.ESUCCESS)
+}
+
+func (m *Module) WasixSockSendFile(ctx context.Context, fd Int32, inFd Int32, offset Uint64, count Uint64, retSent Pointer[Int64]) Errno {
+	return Errno(wasi.ENOSYS)
+}
+
+//func (m *Module) WasixResolve(ctx context.Context, host String, port Uint16, addr Pointer[wasixAddrPort], addrLen Pointer[Uint32]) Errno {
+//	return Errno(wasi.ENOSYS)
+//}
+
+func (m *Module) wasixGetAddrPort(b wasixAddrPort) (sa wasi.SocketAddress, ok bool) {
+	port := binary.LittleEndian.Uint16(b[1:3])
+
+	switch wasi.ProtocolFamily(b[0]) {
+	case wasi.Inet:
+		b = b[3:7]
+	case wasi.Inet6:
+		b = b[3:19]
+	}
+
+	switch len(b) {
+	case 4:
+		m.inet4addr.Port = int(port)
+		copy(m.inet4addr.Addr[:], b)
+		sa = &m.inet4addr
+		ok = true
+	case 16:
+		m.inet6addr.Port = int(port)
+		copy(m.inet6addr.Addr[:], b)
+		sa = &m.inet6addr
+		ok = true
+	}
+	return
+}
+
+func (m *Module) wasixPutAddrPort(b wasixAddrPort, sa wasi.SocketAddress) (ok bool) {
+	switch t := sa.(type) {
+	case *wasi.Inet4Address:
+		b[0] = byte(wasi.Inet)
+		binary.LittleEndian.PutUint16(b[1:3], uint16(t.Port))
+		copy(b[3:], t.Addr[:])
+		ok = true
+
+	case *wasi.Inet6Address:
+		b[0] = byte(wasi.Inet6)
+		binary.LittleEndian.PutUint16(b[1:3], uint16(t.Port))
+		copy(b[3:], t.Addr[:])
+		ok = true
+	}
+	return
+}
+
+// ;;; Union that makes a generic IP address and port
+// (typename $addr_port
+//
+//	(union
+//	  (@witx tag $address_family) u8
+//	  $addr_unspec_port $ip_port:u16 $addr_unspec:u8
+//	  $addr_ip4_port $ip_port:u16 $addr_ip4:u32(4*u8) 2 + 4
+//	  $addr_ip6_port $ip_port:u16 $addr_ip6:u128(8*u16) 2 + 16
+//	  $addr_unix_port $ip_port:u16 $addr_unix:u128(16*u8) 2 + 16
+//	)
+//
+// )
 type wasixAddrPort []byte
+
+func (addr wasixAddrPort) ObjectSize() int {
+	return 8
+}
+
+func (addr wasixAddrPort) LoadObject(memory api.Memory, object []byte) wasixAddrPort {
+	return nil
+}
+
+func (addr wasixAddrPort) StoreObject(memory api.Memory, object []byte) {
+	panic("BUG: socket addresses cannot be stored back to wasm memory")
+}
+
+func (addr wasixAddrPort) FormatObject(w io.Writer, memory api.Memory, object []byte) {
+}
+
+type wasixOptionTimestamp struct {
+	tag       uint8
+	timestamp wasi.Timestamp
+}
+
+func (ts wasixOptionTimestamp) ObjectSize() int {
+	return 0
+}
+
+func (ts wasixOptionTimestamp) LoadObject(memory api.Memory, object []byte) wasixOptionTimestamp {
+	return wasixOptionTimestamp{}
+}
+
+func (ts wasixOptionTimestamp) StoreObject(memory api.Memory, object []byte) {
+}
+
+func (ts wasixOptionTimestamp) FormatObject(w io.Writer, memory api.Memory, object []byte) {
+}

--- a/imports/wasi_snapshot_preview1/wasix.go
+++ b/imports/wasi_snapshot_preview1/wasix.go
@@ -266,10 +266,7 @@ func (addr wasixAddrPort) StoreObject(memory api.Memory, object []byte) {
 func (addr wasixAddrPort) FormatObject(w io.Writer, memory api.Memory, object []byte) {
 }
 
-type wasixOptionTimestamp struct {
-	tag       uint8
-	timestamp wasi.Timestamp
-}
+type wasixOptionTimestamp []byte
 
 func (ts wasixOptionTimestamp) ObjectSize() int {
 	return 0


### PR DESCRIPTION
WIP for #42 

Current status:
- Add the first socket API.
- Trying to create a very simple example to test the API. Every single example coming from WASIX requires the WASI threads [1] proposal (https://github.com/WebAssembly/threads). With WASI threads I don't think we will be able to run binaries/projects targeted for wasmer.
- The WASIX ecosystem is very new and sometimes unstable.

Next steps:
- [ ] Split into multiple host modules to match what is expected by wasmer targeted binaries. See below.
- [ ] Compile a simple example with Rust or C to iterate and finish the socket API
- [ ] Implement `resolve`.

Imports example:
```
  (import "wasix_32v1" "getcwd" (func $wasix::lib_generated32::wasix_32v1::getcwd::hde9bdae5d79d7468 (type 6)))
  (import "wasix_32v1" "futex_wait" (func $wasix::lib_generated32::wasix_32v1::futex_wait::h39f3cb721b28037e (type 10)))
  (import "wasix_32v1" "futex_wake" (func $wasix::lib_generated32::wasix_32v1::futex_wake::h0dd0314d1018fbe9 (type 6)))
  (import "wasix_32v1" "futex_wake_all" (func $wasix::lib_generated32::wasix_32v1::futex_wake_all::h72d8153137b5cad9 (type 6)))
  (import "wasix_32v1" "sock_open" (func $wasix::lib_generated32::wasix_32v1::sock_open::ha75b32b840663a9d (type 10)))
  (import "wasix_32v1" "sock_set_opt_flag" (func $wasix::lib_generated32::wasix_32v1::sock_set_opt_flag::h27959743738cba80 (type 8)))
  (import "wasix_32v1" "sock_bind" (func $wasix::lib_generated32::wasix_32v1::sock_bind::hdd9cc4506c6610f9 (type 6)))
  (import "wasix_32v1" "sock_listen" (func $wasix::lib_generated32::wasix_32v1::sock_listen::h1d4e40e410a9e789 (type 6)))
  (import "wasix_32v1" "sock_accept_v2" (func $wasix::lib_generated32::wasix_32v1::sock_accept_v2::h87e928500da3bed3 (type 10)))
  (import "wasix_32v1" "resolve" (func $wasix::lib_generated32::wasix_32v1::resolve::h9f1425f52a604d99 (type 14)))
  (import "wasi_snapshot_preview1" "fd_close" (func $wasi::lib_generated::wasi_snapshot_preview1::fd_close::h549bef3802dac542 (type 3)))
  (import "wasi_snapshot_preview1" "fd_write" (func $wasi::lib_generated::wasi_snapshot_preview1::fd_write::h0d8b34deb09d60b1 (type 10)))
  (import "wasi_snapshot_preview1" "sock_recv" (func $wasi::lib_generated::wasi_snapshot_preview1::sock_recv::h5312ba4aabe037ad (type 14)))
  (import "wasi_snapshot_preview1" "sock_send" (func $wasi::lib_generated::wasi_snapshot_preview1::sock_send::h6af7a7878da33ec4 (type 12)))
  (import "wasi_snapshot_preview1" "environ_get" (func $__imported_wasi_snapshot_preview1_environ_get (type 6)))
  (import "wasi_snapshot_preview1" "environ_sizes_get" (func $__imported_wasi_snapshot_preview1_environ_sizes_get (type 6)))
  (import "wasi_snapshot_preview1" "clock_time_get" (func $__imported_wasi_snapshot_preview1_clock_time_get (type 19)))
  (import "wasi_snapshot_preview1" "fd_seek" (func $__imported_wasi_snapshot_preview1_fd_seek (type 21)))
  (import "wasi_snapshot_preview1" "proc_exit" (func $__imported_wasi_snapshot_preview1_proc_exit (type 2)))
  (import "wasi_snapshot_preview1" "sched_yield" (func $__imported_wasi_snapshot_preview1_sched_yield (type 1)))
  (import "wasix_32v1" "callback_signal" (func $__imported_wasix_32v1_callback_signal (type 5)))
  (import "wasix_32v1" "thread_signal" (func $__imported_wasix_32v1_thread_signal (type 6)))
  (import "wasix_32v1" "thread_exit" (func $__imported_wasix_32v1_thread_exit (type 2)))
  (import "wasi" "thread-spawn" (func $__imported_wasi_thread_spawn (type 3)))
  ```

Somehow the following example, will be compiled with WASM threads:
```
use std::io::{Read, Write};
use std::net::{TcpListener, TcpStream, SocketAddr};
use socket2::{Socket, Domain, Type};

fn handle_client(mut stream: TcpStream) {
    let mut buffer = [0; 1024];

    loop {
        match stream.read(&mut buffer) {
            Ok(0) => return,
            Ok(n) => {
                stream.write_all(&buffer[..n]).unwrap();
            }
            Err(_) => return,
        }
    }
}

fn main() {
    let socket = Socket::new(Domain::IPV6, Type::STREAM, None).expect("Failed to create socket");

    let address: SocketAddr = "127.0.0.1:8080".parse().unwrap();
    socket.bind(&address.into()).expect("Failed to bind socket");
    socket.listen(128).expect("Failed to listen on socket");

    let listener: TcpListener = socket.into();
    println!("Server listening on http://127.0.0.1:8080");

    for stream in listener.incoming() {
        match stream {
            Ok(stream) => {
                handle_client(stream);
            }
            Err(e) => {
                eprintln!("Error: {}", e);
            }
        }
    }
}
```


[1] - https://github.com/WebAssembly/wasi-threads

Fixes https://github.com/stealthrocket/wasi-go/issues/32