### PR TITLE
wasi: polymorphic socket option values

### DIFF
--- a/sockets_extension.go
+++ b/sockets_extension.go
@@ -56,15 +56,15 @@ type SocketsExtension interface {
 	// the data into multiple buffers in the manner of readv.
 	SockRecvFrom(ctx context.Context, fd FD, iovecs []IOVec, flags RIFlags) (Size, ROFlags, SocketAddress, Errno)
 
-	// SockGetOptInt gets a socket option.
+	// SockGetOpt gets a socket option.
 	//
 	// Note: This is similar to getsockopt in POSIX.
-	SockGetOptInt(ctx context.Context, fd FD, level SocketOptionLevel, option SocketOption) (int, Errno)
+	SockGetOpt(ctx context.Context, fd FD, level SocketOptionLevel, option SocketOption) (SocketOptionValue, Errno)
 
-	// SockSetOptInt sets a socket option.
+	// SockSetOpt sets a socket option.
 	//
 	// Note: This is similar to setsockopt in POSIX.
-	SockSetOptInt(ctx context.Context, fd FD, level SocketOptionLevel, option SocketOption, value int) Errno
+	SockSetOpt(ctx context.Context, fd FD, level SocketOptionLevel, option SocketOption, value SocketOptionValue) Errno
 
 	// SockLocalAddress gets the local address of the socket.
 	//
@@ -297,6 +297,7 @@ const (
 	RecvTimeout
 	SendTimeout
 	QueryAcceptConnections
+	BindToDevice
 )
 
 func (so SocketOption) String() string {
@@ -329,6 +330,8 @@ func (so SocketOption) String() string {
 		return "SendTimeout"
 	case QueryAcceptConnections:
 		return "QueryAcceptConnections"
+	case BindToDevice:
+		return "BindToDevice"
 	default:
 		return fmt.Sprintf("SocketOption(%d)", so)
 	}
@@ -392,4 +395,20 @@ func (flags AddressInfoFlags) String() (s string) {
 		return fmt.Sprintf("AddressInfoFlags(%d)", flags)
 	}
 	return
+}
+
+// SocketOptionValue is a socket option value.
+type SocketOptionValue interface {
+	String() string
+
+	sockopt()
+}
+
+// IntValue is an integer value.
+type IntValue int
+
+func (IntValue) sockopt() {}
+
+func (i IntValue) String() string {
+	return strconv.Itoa(int(i))
 }

--- a/tracer.go
+++ b/tracer.go
@@ -690,13 +690,13 @@ func (t *Tracer) SockRecvFrom(ctx context.Context, fd FD, iovecs []IOVec, iflags
 	return n, oflags, addr, errno
 }
 
-func (t *Tracer) SockGetOptInt(ctx context.Context, fd FD, level SocketOptionLevel, option SocketOption) (int, Errno) {
+func (t *Tracer) SockGetOpt(ctx context.Context, fd FD, level SocketOptionLevel, option SocketOption) (SocketOptionValue, Errno) {
 	s, ok := t.System.(SocketsExtension)
 	if !ok {
-		return 0, ENOSYS
+		return nil, ENOSYS
 	}
-	t.printf("SockGetOptInt(%d, %s, %s) => ", fd, level, option)
-	value, errno := s.SockGetOptInt(ctx, fd, level, option)
+	t.printf("SockGetOpt(%d, %s, %s) => ", fd, level, option)
+	value, errno := s.SockGetOpt(ctx, fd, level, option)
 	if errno == ESUCCESS {
 		t.printf("%d", value)
 	} else {
@@ -706,13 +706,13 @@ func (t *Tracer) SockGetOptInt(ctx context.Context, fd FD, level SocketOptionLev
 	return value, errno
 }
 
-func (t *Tracer) SockSetOptInt(ctx context.Context, fd FD, level SocketOptionLevel, option SocketOption, value int) Errno {
+func (t *Tracer) SockSetOpt(ctx context.Context, fd FD, level SocketOptionLevel, option SocketOption, value SocketOptionValue) Errno {
 	s, ok := t.System.(SocketsExtension)
 	if !ok {
 		return ENOSYS
 	}
-	t.printf("SockSetOptInt(%d, %s, %s, %d) => ", fd, level, option, value)
-	errno := s.SockSetOptInt(ctx, fd, level, option, value)
+	t.printf("SockSetOpt(%d, %s, %s, %d) => ", fd, level, option, value)
+	errno := s.SockSetOpt(ctx, fd, level, option, value)
 	if errno == ESUCCESS {
 		t.printf("ok")
 	} else {


### PR DESCRIPTION
This PR generalizes the `setsockopt` / `getsockopt` wrappers we had. Previously we had `Sock{Get,Set}OptInt` system calls.

There are a few WasmEdge socket options we don't support yet because the option values have different types (e.g. `struct linger`, `struct timeval`, `char [IFNAMSZ]`), and there are many more weird and wonderful socket options out there:

<img width="608" alt="Screenshot 2023-06-09 at 9 19 17 am" src="https://github.com/stealthrocket/wasi-go/assets/364903/c9fc5ab0-277b-442c-8f04-d7253f7cbd02">


Let's try to stick close to the operating system here. `setsockopt` and `getsockopt` accept and populate a `(void *option_value, socklen_t option_len)` respectively. We can use the same approach as our `SocketAddress` and make a polymorphic `SocketOptionValue` type. As new socket options and values are required in future, we can provide additional implementations of `SocketOptionValue` and can avoid adding new methods to the `wasi.SocketsExtension` interface.

---

WasmEdge has generic `sock_setsockopt` and `sock_getsockopt` host functions, but they've made the mistake of passing the option values to the operating system _verbatim_. They will almost certainly run into issues from endianness, 32-bit vs 64-bit, structures diverging across operating systems, etc.

WASIX has instead defined host functions like `sock_{get|set}_opt_{type}`, but have only defined type = `flag,time,size`. They will either have to implement host functions for every type of option value, or just restrict the options that are available to the guest.

With the approach we're taking here, we can leave these ABI concerns out of the `wasi.SocketsExtension` interface.