### PR TITLE
Add TCP_NODELAY socket option

### DIFF
--- a/imports/wasi_snapshot_preview1/wasmedge.go
+++ b/imports/wasi_snapshot_preview1/wasmedge.go
@@ -132,6 +132,11 @@ func (m *Module) WasmEdgeV2SockRecvFrom(ctx context.Context, fd Int32, iovecs Li
 }
 
 func (m *Module) WasmEdgeSockSetOpt(ctx context.Context, fd Int32, level Int32, option Int32, value Pointer[Int32], valueLen Int32) Errno {
+	// See socket.go
+	switch wasi.SocketOptionLevel(level) {
+	case wasi.TcpLevel:
+		option = option - 0x1000
+	}
 	// Only int options are supported for now.
 	switch wasi.SocketOption(option) {
 	case wasi.Linger, wasi.RecvTimeout, wasi.SendTimeout, wasi.BindToDevice:
@@ -145,6 +150,11 @@ func (m *Module) WasmEdgeSockSetOpt(ctx context.Context, fd Int32, level Int32, 
 }
 
 func (m *Module) WasmEdgeSockGetOpt(ctx context.Context, fd Int32, level Int32, option Int32, value Pointer[Int32], valueLen Int32) Errno {
+	// See socket.go
+	switch wasi.SocketOptionLevel(level) {
+	case wasi.TcpLevel:
+		option = option - 0x1000
+	}
 	// Only int options are supported for now.
 	switch wasi.SocketOption(option) {
 	case wasi.Linger, wasi.RecvTimeout, wasi.SendTimeout, wasi.BindToDevice:

--- a/imports/wasi_snapshot_preview1/wasmedge.go
+++ b/imports/wasi_snapshot_preview1/wasmedge.go
@@ -135,7 +135,7 @@ func (m *Module) WasmEdgeSockSetOpt(ctx context.Context, fd Int32, level Int32, 
 	// See socket.go
 	switch wasi.SocketOptionLevel(level) {
 	case wasi.TcpLevel:
-		option = option - 0x1000
+		option += 0x1000
 	}
 	// Only int options are supported for now.
 	switch wasi.SocketOption(option) {
@@ -153,7 +153,7 @@ func (m *Module) WasmEdgeSockGetOpt(ctx context.Context, fd Int32, level Int32, 
 	// See socket.go
 	switch wasi.SocketOptionLevel(level) {
 	case wasi.TcpLevel:
-		option = option - 0x1000
+		option -= 0x1000
 	}
 	// Only int options are supported for now.
 	switch wasi.SocketOption(option) {

--- a/imports/wasi_snapshot_preview1/wasmedge.go
+++ b/imports/wasi_snapshot_preview1/wasmedge.go
@@ -153,7 +153,7 @@ func (m *Module) WasmEdgeSockGetOpt(ctx context.Context, fd Int32, level Int32, 
 	// See socket.go
 	switch wasi.SocketOptionLevel(level) {
 	case wasi.TcpLevel:
-		option -= 0x1000
+		option += 0x1000
 	}
 	// Only int options are supported for now.
 	switch wasi.SocketOption(option) {

--- a/socket.go
+++ b/socket.go
@@ -305,7 +305,7 @@ func (st SocketType) String() string {
 type SocketOptionLevel int32
 
 const (
-	SocketLevel SocketOptionLevel = 0 // SOC_SOCKET
+	SocketLevel SocketOptionLevel = 0 // SOL_SOCKET
 	TcpLevel    SocketOptionLevel = 6 // IPPROTO_TCP
 )
 
@@ -322,7 +322,7 @@ func (sl SocketOptionLevel) String() string {
 type SocketOption int32
 
 const (
-	// SOC_SOCKET level options.
+	// SOL_SOCKET level options.
 	ReuseAddress SocketOption = iota
 	QuerySocketType
 	QuerySocketError

--- a/socket.go
+++ b/socket.go
@@ -305,8 +305,8 @@ func (st SocketType) String() string {
 type SocketOptionLevel int32
 
 const (
-	SocketLevel SocketOptionLevel = 0
-	TcpLevel    SocketOptionLevel = 6
+	SocketLevel SocketOptionLevel = 0 // SOC_SOCKET
+	TcpLevel    SocketOptionLevel = 6 // IPPROTO_TCP
 )
 
 func (sl SocketOptionLevel) String() string {
@@ -322,6 +322,7 @@ func (sl SocketOptionLevel) String() string {
 type SocketOption int32
 
 const (
+	// SOC_SOCKET level options.
 	ReuseAddress SocketOption = iota
 	QuerySocketType
 	QuerySocketError
@@ -337,7 +338,9 @@ const (
 	SendTimeout
 	QueryAcceptConnections
 	BindToDevice
-	TcpNoDelay
+
+	// 0x1000 + iota are IPPROTO_TCP level options.
+	TcpNoDelay SocketOption = 0x1000 + iota
 )
 
 func (so SocketOption) String() string {

--- a/socket.go
+++ b/socket.go
@@ -305,7 +305,8 @@ func (st SocketType) String() string {
 type SocketOptionLevel int32
 
 const (
-	SocketLevel SocketOptionLevel = iota
+	SocketLevel SocketOptionLevel = 0
+	TcpLevel    SocketOptionLevel = 6
 )
 
 func (sl SocketOptionLevel) String() string {
@@ -336,6 +337,7 @@ const (
 	SendTimeout
 	QueryAcceptConnections
 	BindToDevice
+	TcpNoDelay
 )
 
 func (so SocketOption) String() string {
@@ -370,6 +372,8 @@ func (so SocketOption) String() string {
 		return "QueryAcceptConnections"
 	case BindToDevice:
 		return "BindToDevice"
+	case TcpNoDelay:
+		return "TcpNoDelay"
 	default:
 		return fmt.Sprintf("SocketOption(%d)", so)
 	}

--- a/systems/unix/system.go
+++ b/systems/unix/system.go
@@ -565,6 +565,8 @@ func (s *System) SockGetOpt(ctx context.Context, fd wasi.FD, level wasi.SocketOp
 	switch level {
 	case wasi.SocketLevel:
 		sysLevel = unix.SOL_SOCKET
+	case wasi.TcpLevel:
+		sysLevel = unix.IPPROTO_TCP
 	default:
 		return nil, wasi.EINVAL
 	}
@@ -592,6 +594,8 @@ func (s *System) SockGetOpt(ctx context.Context, fd wasi.FD, level wasi.SocketOp
 		sysOption = unix.SO_RCVLOWAT
 	case wasi.QueryAcceptConnections:
 		sysOption = unix.SO_ACCEPTCONN
+	case wasi.TcpNoDelay:
+		sysOption = unix.TCP_NODELAY
 	case wasi.Linger:
 		// This returns a struct linger value.
 		return nil, wasi.ENOTSUP // TODO: implement SO_LINGER
@@ -638,6 +642,8 @@ func (s *System) SockSetOpt(ctx context.Context, fd wasi.FD, level wasi.SocketOp
 	switch level {
 	case wasi.SocketLevel:
 		sysLevel = unix.SOL_SOCKET
+	case wasi.TcpLevel:
+		sysLevel = unix.IPPROTO_TCP
 	default:
 		return wasi.EINVAL
 	}

--- a/systems/unix/system.go
+++ b/systems/unix/system.go
@@ -671,6 +671,8 @@ func (s *System) SockSetOpt(ctx context.Context, fd wasi.FD, level wasi.SocketOp
 		sysOption = unix.SO_RCVLOWAT
 	case wasi.QueryAcceptConnections:
 		sysOption = unix.SO_ACCEPTCONN
+	case wasi.TcpNoDelay:
+		sysOption = unix.TCP_NODELAY
 	case wasi.Linger:
 		// This accepts a struct linger value.
 		return wasi.ENOTSUP // TODO: implement SO_LINGER


### PR DESCRIPTION
The Python Requests library set TCP_NODELAY on sockets by default.