### PR TITLE
wasitest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,10 @@ jobs:
         go-version: '1.20'
         check-latest: true
 
+    # We run the tests 20 times because sometimes it helps highlight flaky
+    # behaviors that do not trigger on a single pass.
     - name: Go Tests
-      run: make test
+      run: make test count=20
 
   WASI:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: all clean test testdata wasi-libc wasi-testsuite
 
+count ?= 1
+
 wasi-go.src = \
 	$(wildcard *.go) \
 	$(wildcard */*.go) \
@@ -27,7 +29,7 @@ clean:
 	rm -f $(testdata.files)
 
 test: testdata
-	go test ./...
+	go test -count=$(count) ./...
 
 testdata: $(testdata.files)
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The package layout is as follows:
 - [`systems/unix`][unix-system] a Unix implementation (tested on Linux and macOS)
 - [`imports/wasi_snapshot_preview1`][host-module] a host module for the [wazero][wazero] runtime
 - [`cmd/wasirun`][wasirun] a command to run WebAssembly modules
-- [`testwasi`][testwasi] a test suite against the WASI interface
+- [`wasitest`][wasitest] a test suite against the WASI interface
 
 To run a WebAssembly module, it's also necessary to prepare clocks and "preopens"
 (files/directories that the WebAssembly module can access). To see how it all fits
@@ -125,7 +125,7 @@ Remember to be respectful and open minded!
 [preview1]: https://github.com/WebAssembly/WASI/blob/e324ce3/legacy/preview1/docs.md
 [wazero]: https://wazero.io
 [wasirun]: https://github.com/stealthrocket/wasi-go/blob/main/cmd/wasirun/main.go
-[testwasi]: https://github.com/stealthrocket/wasi-go/tree/main/testwasi
+[wasitest]: https://github.com/stealthrocket/wasi-go/tree/main/wasitest
 [tracer]: https://github.com/stealthrocket/wasi-go/blob/main/tracer.go
 [sockets-extension]: https://github.com/stealthrocket/wasi-go/blob/main/sockets_extension.go
 [gotip]: https://pkg.go.dev/golang.org/dl/gotip

--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/tetratelabs/wazero v1.2.0
 	golang.org/x/sys v0.8.0
 )
+
+require golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,7 @@ github.com/stealthrocket/wazergo v0.19.1 h1:BPrITETPgSFwiytwmToO0MbUC/+RGC39JScz
 github.com/stealthrocket/wazergo v0.19.1/go.mod h1:riI0hxw4ndZA5e6z7PesHg2BtTftcZaMxRcoiGGipTs=
 github.com/tetratelabs/wazero v1.2.0 h1:I/8LMf4YkCZ3r2XaL9whhA0VMyAvF6QE+O7rco0DCeQ=
 github.com/tetratelabs/wazero v1.2.0/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/sockets/socket.go
+++ b/internal/sockets/socket.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"syscall"
@@ -41,7 +42,17 @@ func Socket(rawAddr string) (u *url.URL, sa syscall.Sockaddr, fd int, err error)
 
 // Close closes a file descriptor created with Socket, Listen or Dial.
 func Close(fd int) error {
-	return syscall.Close(fd)
+	if fd < 0 {
+		return syscall.EBADF
+	}
+	err := syscall.Close(fd)
+	if err != nil {
+		if err == syscall.EBADF {
+			println("DEBUG: close", fd, "=> EBADF")
+			debug.PrintStack()
+		}
+	}
+	return err
 }
 
 func socketAddress(network, addr string) (int, syscall.Sockaddr, error) {

--- a/systems/unix/file.go
+++ b/systems/unix/file.go
@@ -20,7 +20,13 @@ func (fd FD) FDAllocate(ctx context.Context, offset, length wasi.FileSize) wasi.
 }
 
 func (fd FD) FDClose(ctx context.Context) wasi.Errno {
-	err := ignoreEINTR(func() error { return unix.Close(int(fd)) })
+	// It's unclear what to do for EINTR on Linux, so do nothing and assume the
+	// file descriptor has been closed.
+	//
+	// See:
+	// - https://man7.org/linux/man-pages/man2/close.2.html
+	// - https://lwn.net/Articles/576478/
+	err := closeTraceEBADF(int(fd))
 	return makeErrno(err)
 }
 

--- a/systems/unix/readdir_darwin.go
+++ b/systems/unix/readdir_darwin.go
@@ -35,7 +35,9 @@ func (d *dirbuf) readDirEntries(entries []wasi.DirEntry, cookie wasi.DirCookie, 
 	}
 
 	if cookie < d.cookie {
-		if _, err := syscall.Seek(d.fd, 0, 0); err != nil {
+		if _, err := ignoreEINTR2(func() (int64, error) {
+			return syscall.Seek(d.fd, 0, 0)
+		}); err != nil {
 			return 0, err
 		}
 		d.offset = 0
@@ -54,7 +56,9 @@ func (d *dirbuf) readDirEntries(entries []wasi.DirEntry, cookie wasi.DirCookie, 
 			if numEntries > 0 {
 				return numEntries, nil
 			}
-			n, err := syscall.Getdirentries(d.fd, d.buffer[:], &d.basep)
+			n, err := ignoreEINTR2(func() (int, error) {
+				return syscall.Getdirentries(d.fd, d.buffer[:], &d.basep)
+			})
 			if err != nil {
 				return numEntries, err
 			}

--- a/systems/unix/readdir_linux.go
+++ b/systems/unix/readdir_linux.go
@@ -34,7 +34,9 @@ func (d *dirbuf) readDirEntries(entries []wasi.DirEntry, cookie wasi.DirCookie, 
 	}
 
 	if cookie < d.cookie {
-		if _, err := unix.Seek(d.fd, 0, unix.SEEK_SET); err != nil {
+		if _, err := ignoreEINTR2(func() (int64, error) {
+			return unix.Seek(d.fd, 0, unix.SEEK_SET)
+		}); err != nil {
 			return 0, err
 		}
 		d.offset = 0
@@ -52,7 +54,9 @@ func (d *dirbuf) readDirEntries(entries []wasi.DirEntry, cookie wasi.DirCookie, 
 			if numEntries > 0 {
 				return numEntries, nil
 			}
-			n, err := unix.Getdents(d.fd, d.buffer[:])
+			n, err := ignoreEINTR2(func() (int, error) {
+				return unix.Getdents(d.fd, d.buffer[:])
+			})
 			if err != nil {
 				return numEntries, err
 			}

--- a/systems/unix/syscall_darwin.go
+++ b/systems/unix/syscall_darwin.go
@@ -15,7 +15,7 @@ func accept(socket, flags int) (int, unix.Sockaddr, error) {
 	}
 	if (flags & unix.O_NONBLOCK) != 0 {
 		if err := unix.SetNonblock(conn, true); err != nil {
-			unix.Close(conn)
+			closeTraceEBADF(conn)
 			return -1, addr, err
 		}
 	}
@@ -65,8 +65,8 @@ func pipeCloseOnExec(fds []int) error {
 }
 
 func closePipe(fds []int) {
-	unix.Close(fds[1])
-	unix.Close(fds[0])
+	closeTraceEBADF(fds[1])
+	closeTraceEBADF(fds[0])
 	fds[0] = -1
 	fds[1] = -1
 }

--- a/systems/unix/system.go
+++ b/systems/unix/system.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"runtime"
 	"strconv"
 	"sync"
 	"time"
@@ -424,6 +425,26 @@ func (s *System) SockShutdown(ctx context.Context, fd wasi.FD, flags wasi.SDFlag
 		sysHow = unix.SHUT_WR
 	default:
 		return wasi.EINVAL
+	}
+	// Linux allows calling shutdown(2) on listening sockets, but not Darwin.
+	// To provide a portable behavior we align on the POSIX behavior which says
+	// that shutting down non-connected sockets must return ENOTCONN.
+	//
+	// Note that this may cause issues in the future if applications need a way
+	// to break out of a blocking accept(2) call. We could relax this limitation
+	// down the line, tho keep in mind that applications may be better served by
+	// not relying on system-specific behaviors and should use synchronization
+	// mechanisms is user-space to maximize portability.
+	//
+	// For more context see: https://bugzilla.kernel.org/show_bug.cgi?id=106241
+	if runtime.GOOS == "linux" {
+		v, err := unix.GetsockoptInt(int(socket), unix.SOL_SOCKET, unix.SO_ACCEPTCONN)
+		if err != nil {
+			return makeErrno(err)
+		}
+		if v != 0 {
+			return wasi.ENOTCONN
+		}
 	}
 	err := unix.Shutdown(int(socket), sysHow)
 	return makeErrno(err)

--- a/systems/unix/system.go
+++ b/systems/unix/system.go
@@ -446,6 +446,14 @@ func (s *System) SockOpen(ctx context.Context, pf wasi.ProtocolFamily, socketTyp
 	default:
 		return -1, wasi.EINVAL
 	}
+	if socketType == wasi.AnySocket {
+		switch protocol {
+		case wasi.TCPProtocol:
+			socketType = wasi.StreamSocket
+		case wasi.UDPProtocol:
+			socketType = wasi.DatagramSocket
+		}
+	}
 	var fdType wasi.FileType
 	var sysType int
 	switch socketType {

--- a/systems/unix/system.go
+++ b/systems/unix/system.go
@@ -235,6 +235,9 @@ func (s *System) PollOneOff(ctx context.Context, subscriptions []wasi.Subscripti
 	}
 
 	if n > 0 && s.pollfds[0].Revents != 0 {
+		if s.pollfds[0].Fd != int32(wakefd) {
+			panic("kernel reordered pollfds")
+		}
 		// If the wake fd was notified it means the system was shut down,
 		// we report this by cancelling all subscriptions.
 		//

--- a/wasitest/poll.go
+++ b/wasitest/poll.go
@@ -69,9 +69,8 @@ var poll = testSuite{
 		assertEqual(t, numEvents, 1)
 		assertEqual(t, errno, wasi.ESUCCESS)
 		assertEqual(t, evs[0], wasi.Event{
-			UserData:    42,
-			EventType:   wasi.FDReadEvent,
-			FDReadWrite: wasi.EventFDReadWrite{NBytes: 1},
+			UserData:  42,
+			EventType: wasi.FDReadEvent,
 		})
 
 		n, errno = sys.FDRead(ctx, 0, []wasi.IOVec{buffer})
@@ -129,9 +128,8 @@ var poll = testSuite{
 			assertEqual(t, numEvents, 1)
 			assertEqual(t, errno, wasi.ESUCCESS)
 			assertEqual(t, evs[0], wasi.Event{
-				UserData:    42,
-				EventType:   wasi.FDWriteEvent,
-				FDReadWrite: wasi.EventFDReadWrite{NBytes: 1},
+				UserData:  42,
+				EventType: wasi.FDWriteEvent,
 			})
 
 			n, errno = sys.FDWrite(ctx, 1, []wasi.IOVec{[]byte("Hello, World!")})

--- a/wasitest/poll.go
+++ b/wasitest/poll.go
@@ -3,7 +3,6 @@ package wasitest
 import (
 	"context"
 	"io"
-	"os"
 	"testing"
 	"time"
 
@@ -37,8 +36,7 @@ var poll = testSuite{
 	},
 
 	"read from stdin": func(t *testing.T, ctx context.Context, newSystem newSystem) {
-		stdinR, stdinW, err := os.Pipe()
-		assertOK(t, err)
+		stdinR, stdinW := io.Pipe()
 		defer stdinW.Close()
 		defer stdinR.Close()
 
@@ -80,20 +78,9 @@ var poll = testSuite{
 	},
 
 	"write to stdout": func(t *testing.T, ctx context.Context, newSystem newSystem) {
-		stdinR, stdinW, err := os.Pipe()
-		assertOK(t, err)
-		defer stdinR.Close()
-		defer stdinW.Close()
-
-		stdoutR, stdoutW, err := os.Pipe()
-		assertOK(t, err)
+		stdoutR, stdoutW := io.Pipe()
 		defer stdoutR.Close()
 		defer stdoutW.Close()
-
-		stderrR, stderrW, err := os.Pipe()
-		assertOK(t, err)
-		defer stderrR.Close()
-		defer stderrW.Close()
 
 		ch := make(chan []byte)
 		go func() {
@@ -103,9 +90,7 @@ var poll = testSuite{
 		}()
 
 		sys := newSystem(TestConfig{
-			Stdin:  stdinR,
 			Stdout: stdoutW,
-			Stderr: stderrW,
 		})
 
 		errno := sys.FDStatSetFlags(ctx, 1, wasi.NonBlock)

--- a/wasitest/poll.go
+++ b/wasitest/poll.go
@@ -1,0 +1,241 @@
+package wasitest
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stealthrocket/wasi-go"
+)
+
+var poll = testSuite{
+	"with no subscriptions returns EINVAL": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		numEvents, errno := sys.PollOneOff(ctx, nil, nil)
+		assertEqual(t, errno, wasi.EINVAL)
+		assertEqual(t, numEvents, 0)
+	},
+
+	"an unknown file number sets the event to EBADF": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+
+		subs := []wasi.Subscription{
+			wasi.MakeSubscriptionFDReadWrite(42, wasi.FDReadEvent, wasi.SubscriptionFDReadWrite{FD: 1234}),
+		}
+		evs := make([]wasi.Event, len(subs))
+
+		numEvents, errno := sys.PollOneOff(ctx, subs, evs)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, numEvents, 1)
+		assertEqual(t, evs[0], wasi.Event{
+			UserData:  42,
+			Errno:     wasi.EBADF,
+			EventType: wasi.FDReadEvent,
+		})
+	},
+
+	"read from stdin": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		stdinR, stdinW, err := os.Pipe()
+		assertOK(t, err)
+		defer stdinW.Close()
+		defer stdinR.Close()
+
+		sys := newSystem(TestConfig{
+			Stdin: stdinR,
+		})
+
+		errno := sys.FDStatSetFlags(ctx, 0, wasi.NonBlock)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		buffer := make([]byte, 32)
+		n, errno := sys.FDRead(ctx, 0, []wasi.IOVec{buffer})
+		assertEqual(t, n, ^wasi.Size(0))
+		assertEqual(t, errno, wasi.EAGAIN)
+
+		go func() {
+			n, err := io.WriteString(stdinW, "Hello, World!")
+			assertOK(t, err)
+			assertEqual(t, n, 13)
+		}()
+
+		subs := []wasi.Subscription{
+			wasi.MakeSubscriptionFDReadWrite(42, wasi.FDReadEvent, wasi.SubscriptionFDReadWrite{FD: 0}),
+		}
+		evs := make([]wasi.Event, len(subs))
+
+		numEvents, errno := sys.PollOneOff(ctx, subs, evs)
+		assertEqual(t, numEvents, 1)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, evs[0], wasi.Event{
+			UserData:    42,
+			EventType:   wasi.FDReadEvent,
+			FDReadWrite: wasi.EventFDReadWrite{NBytes: 1},
+		})
+
+		n, errno = sys.FDRead(ctx, 0, []wasi.IOVec{buffer})
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, n, 13)
+		assertEqual(t, string(buffer[:n]), "Hello, World!")
+	},
+
+	"write to stdout": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		stdinR, stdinW, err := os.Pipe()
+		assertOK(t, err)
+		defer stdinR.Close()
+		defer stdinW.Close()
+
+		stdoutR, stdoutW, err := os.Pipe()
+		assertOK(t, err)
+		defer stdoutR.Close()
+		defer stdoutW.Close()
+
+		stderrR, stderrW, err := os.Pipe()
+		assertOK(t, err)
+		defer stderrR.Close()
+		defer stderrW.Close()
+
+		ch := make(chan []byte)
+		go func() {
+			b, err := io.ReadAll(stdoutR)
+			assertOK(t, err)
+			ch <- b
+		}()
+
+		sys := newSystem(TestConfig{
+			Stdin:  stdinR,
+			Stdout: stdoutW,
+			Stderr: stderrW,
+		})
+
+		errno := sys.FDStatSetFlags(ctx, 1, wasi.NonBlock)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		n, errno := sys.FDWrite(ctx, 1, []wasi.IOVec{[]byte("Hello, World!")})
+		if errno == wasi.ESUCCESS {
+			assertEqual(t, errno, wasi.ESUCCESS)
+			assertEqual(t, n, 13)
+		} else {
+			assertEqual(t, n, ^wasi.Size(0))
+			assertEqual(t, errno, wasi.EAGAIN)
+
+			subs := []wasi.Subscription{
+				wasi.MakeSubscriptionFDReadWrite(42, wasi.FDWriteEvent, wasi.SubscriptionFDReadWrite{FD: 1}),
+			}
+			evs := make([]wasi.Event, len(subs))
+
+			numEvents, errno := sys.PollOneOff(ctx, subs, evs)
+			assertEqual(t, numEvents, 1)
+			assertEqual(t, errno, wasi.ESUCCESS)
+			assertEqual(t, evs[0], wasi.Event{
+				UserData:    42,
+				EventType:   wasi.FDWriteEvent,
+				FDReadWrite: wasi.EventFDReadWrite{NBytes: 1},
+			})
+
+			n, errno = sys.FDWrite(ctx, 1, []wasi.IOVec{[]byte("Hello, World!")})
+			assertEqual(t, errno, wasi.ESUCCESS)
+			assertEqual(t, n, 13)
+		}
+
+		assertEqual(t, sys.FDClose(ctx, 1), wasi.ESUCCESS)
+		assertEqual(t, string(<-ch), "Hello, World!")
+	},
+
+	"monotonic clock with timeout in the future":   testPollTimeout(wasi.Monotonic, futureTimeout),
+	"realtime clock with timeout in the future":    testPollTimeout(wasi.Realtime, futureTimeout),
+	"process CPU clock with timeout in the future": testPollTimeout(wasi.ProcessCPUTimeID, futureTimeout),
+	"thread CPU clock with timeout in the future":  testPollTimeout(wasi.ThreadCPUTimeID, futureTimeout),
+
+	"monotonic clock with timeout in the past":   testPollTimeout(wasi.Monotonic, pastTimeout),
+	"realtime clock with timeout in the past":    testPollTimeout(wasi.Realtime, pastTimeout),
+	"process CPU clock with timeout in the past": testPollTimeout(wasi.ProcessCPUTimeID, pastTimeout),
+	"thread CPU clock with timeout in the past":  testPollTimeout(wasi.ThreadCPUTimeID, pastTimeout),
+
+	"monotonic clock with deadline in the future":   testPollDeadline(wasi.Monotonic, futureTimeout),
+	"realtime clock with deadline in the future":    testPollDeadline(wasi.Realtime, futureTimeout),
+	"process CPU clock with deadline in the future": testPollDeadline(wasi.ProcessCPUTimeID, futureTimeout),
+	"thread CPU clock with deadline in the future":  testPollDeadline(wasi.ThreadCPUTimeID, futureTimeout),
+
+	"monotonic clock with deadline in the past":   testPollDeadline(wasi.Monotonic, pastTimeout),
+	"realtime clock with deadline in the past":    testPollDeadline(wasi.Realtime, pastTimeout),
+	"process CPU clock with deadline in the past": testPollDeadline(wasi.ProcessCPUTimeID, pastTimeout),
+	"thread CPU clock with deadline in the past":  testPollDeadline(wasi.ThreadCPUTimeID, pastTimeout),
+}
+
+const (
+	futureTimeout = 10 * time.Millisecond
+	pastTimeout   = -1 * time.Second // longer absolute value to notice if poll_oneoff waits or blocks
+)
+
+func testPollTimeout(clock wasi.ClockID, timeout time.Duration) testFunc {
+	return func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{
+			Now: time.Now,
+		})
+
+		subs := []wasi.Subscription{
+			wasi.MakeSubscriptionClock(42, wasi.SubscriptionClock{
+				ID:        clock,
+				Timeout:   wasi.Timestamp(timeout),
+				Precision: wasi.Timestamp(time.Millisecond),
+			}),
+		}
+		evs := make([]wasi.Event, len(subs))
+		now := time.Now()
+
+		numEvents, errno := sys.PollOneOff(ctx, subs, evs)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, numEvents, 1)
+		if evs[0].Errno == wasi.ENOTSUP {
+			t.Skip("clock not supported on this system")
+		}
+		if elapsed := time.Since(now); elapsed < timeout {
+			t.Errorf("returned too early: %s < 10ms", elapsed)
+		}
+		assertEqual(t, evs[0], wasi.Event{
+			UserData:  42,
+			EventType: wasi.ClockEvent,
+		})
+	}
+}
+
+func testPollDeadline(clock wasi.ClockID, timeout time.Duration) testFunc {
+	return func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{
+			Now: time.Now,
+		})
+
+		timestamp, errno := sys.ClockTimeGet(ctx, clock, 1)
+		switch errno {
+		case wasi.ESUCCESS:
+		case wasi.ENOTSUP:
+			t.Skip("clock not supported on this system")
+		default:
+			t.Fatal("ClockTimeGet:", errno)
+		}
+
+		subs := []wasi.Subscription{
+			wasi.MakeSubscriptionClock(42, wasi.SubscriptionClock{
+				ID:        clock,
+				Timeout:   timestamp + wasi.Timestamp(timeout),
+				Precision: wasi.Timestamp(time.Millisecond),
+				Flags:     wasi.Abstime,
+			}),
+		}
+		evs := make([]wasi.Event, len(subs))
+		now := time.Now()
+
+		numEvents, errno := sys.PollOneOff(ctx, subs, evs)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, numEvents, 1)
+		if elapsed := time.Since(now); elapsed < timeout {
+			t.Errorf("PollOneOff returned too early: %s < 10ms", elapsed)
+		}
+		assertEqual(t, evs[0], wasi.Event{
+			UserData:  42,
+			EventType: wasi.ClockEvent,
+		})
+	}
+}

--- a/wasitest/proc.go
+++ b/wasitest/proc.go
@@ -1,0 +1,117 @@
+package wasitest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stealthrocket/wasi-go"
+	"github.com/tetratelabs/wazero/sys"
+)
+
+var proc = testSuite{
+	"ProcExit panics with a value of type sys.ExitError": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		s := newSystem(TestConfig{})
+
+		defer func() {
+			switch v := recover().(type) {
+			case nil:
+				t.Error("proc_exit must not return")
+			case *sys.ExitError:
+				if exitCode := v.ExitCode(); exitCode != 42 {
+					t.Errorf("exit error contains the wrong exit code: %d", exitCode)
+				}
+			default:
+				t.Errorf("proc_exit panicked with a value of the wrong type: %T", v)
+			}
+		}()
+
+		s.ProcExit(ctx, 42)
+	},
+
+	"ProcRaise panics with a value of type sys.ExitError": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		s := newSystem(TestConfig{})
+
+		defer func() {
+			switch v := recover().(type) {
+			case nil:
+				t.Error("proc_raise must not return")
+			case *sys.ExitError:
+				if exitCode := v.ExitCode(); exitCode != 127+42 {
+					t.Errorf("exit error contains the wrong exit code: %d", exitCode)
+				}
+			default:
+				t.Errorf("proc_raise panicked with a value of the wrong type: %T", v)
+			}
+		}()
+
+		s.ProcRaise(ctx, 42)
+	},
+
+	"SchedYield does nothing": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		s := newSystem(TestConfig{})
+		assertEqual(t, s.SchedYield(ctx), wasi.ESUCCESS)
+	},
+
+	"ArgsSizesGet returns zero when there are no arguments": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		s := newSystem(TestConfig{})
+		count, bytes, errno := s.ArgsSizesGet(ctx)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, count, 0)
+		assertEqual(t, bytes, 0)
+	},
+
+	"ArgsSizesGet returns the number of arguments and their size in bytes": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		args := []string{
+			"hello",
+			"world",
+		}
+		s := newSystem(TestConfig{
+			Args: args,
+		})
+		gotCount, gotBytes, errno := s.ArgsSizesGet(ctx)
+		wantCount, wantBytes := wasi.SizesGet(args)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, gotCount, wantCount)
+		assertEqual(t, gotBytes, wantBytes)
+	},
+
+	"EnvironSizesGet returns zero when there are no environment variables": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		s := newSystem(TestConfig{})
+		count, bytes, errno := s.EnvironSizesGet(ctx)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, count, 0)
+		assertEqual(t, bytes, 0)
+	},
+
+	"EnvironSizesGet returns the number of environment variables and their size in bytes": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		environ := []string{
+			"hello",
+			"world",
+		}
+		s := newSystem(TestConfig{
+			Environ: environ,
+		})
+		gotCount, gotBytes, errno := s.EnvironSizesGet(ctx)
+		wantCount, wantBytes := wasi.SizesGet(environ)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, gotCount, wantCount)
+		assertEqual(t, gotBytes, wantBytes)
+	},
+
+	"ClockResGet with an invalid clock id returns EINVAL": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		s := newSystem(TestConfig{
+			Now: time.Now,
+		})
+		_, errno := s.ClockResGet(ctx, 42)
+		assertEqual(t, errno, wasi.EINVAL)
+	},
+
+	"ClockTimeGet with an invalid clock id returns EINVAL": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		s := newSystem(TestConfig{
+			Now: time.Now,
+		})
+		_, errno := s.ClockTimeGet(ctx, 42, 0)
+		assertEqual(t, errno, wasi.EINVAL)
+	},
+}

--- a/wasitest/socket.go
+++ b/wasitest/socket.go
@@ -503,11 +503,11 @@ func testSocketConnectAndAccept(family wasi.ProtocolFamily, typ wasi.SocketType,
 		assertEqual(t, errno, wasi.ESUCCESS)
 
 		clientAddr, errno := sys.SockConnect(ctx, client, serverAddr)
-		assertNotEqual(t, clientAddr, nil)
-		assertEqual(t, clientAddr.Family(), bind.Family())
 		if errno != wasi.ESUCCESS {
 			assertEqual(t, errno, wasi.EINPROGRESS)
 		}
+		assertNotEqual(t, clientAddr, nil)
+		assertEqual(t, clientAddr.Family(), bind.Family())
 
 		subs := []wasi.Subscription{
 			wasi.MakeSubscriptionFDReadWrite(2, wasi.FDWriteEvent, wasi.SubscriptionFDReadWrite{

--- a/wasitest/socket.go
+++ b/wasitest/socket.go
@@ -181,5 +181,15 @@ func sockOpen(t *testing.T, ctx context.Context, sys wasi.System, family wasi.Pr
 	t.Helper()
 	sock, errno := sys.SockOpen(ctx, family, typ, proto, wasi.AllRights, wasi.AllRights)
 	skipIfNotImplemented(t, errno)
+
+	if errno == wasi.ESUCCESS {
+		opt, errno := sys.SockGetOpt(ctx, sock, wasi.SocketLevel, wasi.QuerySocketError)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		val, ok := opt.(wasi.IntValue)
+		assertEqual(t, ok, true)
+		assertEqual(t, wasi.Errno(val), wasi.ESUCCESS)
+	}
+
 	return sock, errno
 }

--- a/wasitest/socket.go
+++ b/wasitest/socket.go
@@ -1,0 +1,185 @@
+package wasitest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stealthrocket/wasi-go"
+)
+
+var socket = testSuite{
+	"can create a tcp socket for ipv4": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		sock, errno := sockOpen(t, ctx, sys, wasi.InetFamily, wasi.StreamSocket, wasi.TCPProtocol)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
+	},
+
+	"can create a udp socket for ipv4": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		sock, errno := sockOpen(t, ctx, sys, wasi.InetFamily, wasi.DatagramSocket, wasi.UDPProtocol)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
+	},
+
+	"can create a tcp socket for ipv6": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		sock, errno := sockOpen(t, ctx, sys, wasi.Inet6Family, wasi.StreamSocket, wasi.TCPProtocol)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
+	},
+
+	"can create a udp socket for ipv6": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		sock, errno := sockOpen(t, ctx, sys, wasi.Inet6Family, wasi.DatagramSocket, wasi.UDPProtocol)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
+	},
+
+	"can create a stream socket for ipv4 with the default protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		sock, errno := sockOpen(t, ctx, sys, wasi.InetFamily, wasi.StreamSocket, 0)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
+	},
+
+	"can create a datagram socket for ipv6 with the default protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		sock, errno := sockOpen(t, ctx, sys, wasi.InetFamily, wasi.DatagramSocket, 0)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
+	},
+
+	"can create a stream socket for unix with the default protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		sock, errno := sockOpen(t, ctx, sys, wasi.UnixFamily, wasi.StreamSocket, 0)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
+	},
+
+	"can create a datagram socket for unix with the default protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		sock, errno := sockOpen(t, ctx, sys, wasi.UnixFamily, wasi.DatagramSocket, 0)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
+	},
+
+	"cannot create an ipv4 stream socket with the udp protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		sock, errno := sockOpen(t, ctx, sys, wasi.InetFamily, wasi.StreamSocket, wasi.UDPProtocol)
+		assertEqual(t, sock, ^wasi.FD(0))
+		assertEqual(t, errno, wasi.EPROTOTYPE)
+	},
+
+	"cannot create an ipv4 datagram socket with the tcp protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		sock, errno := sockOpen(t, ctx, sys, wasi.InetFamily, wasi.DatagramSocket, wasi.TCPProtocol)
+		assertEqual(t, sock, ^wasi.FD(0))
+		assertEqual(t, errno, wasi.EPROTOTYPE)
+	},
+
+	"cannot create an ipv6 stream socket with the udp protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		sock, errno := sockOpen(t, ctx, sys, wasi.Inet6Family, wasi.StreamSocket, wasi.UDPProtocol)
+		assertEqual(t, sock, ^wasi.FD(0))
+		assertEqual(t, errno, wasi.EPROTOTYPE)
+	},
+
+	"cannot create an ipv6 datagram socket with the tcp protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		sock, errno := sockOpen(t, ctx, sys, wasi.Inet6Family, wasi.DatagramSocket, wasi.TCPProtocol)
+		assertEqual(t, sock, ^wasi.FD(0))
+		assertEqual(t, errno, wasi.EPROTOTYPE)
+	},
+
+	"cannot create a unix stream socket with the udp protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		sock, errno := sockOpen(t, ctx, sys, wasi.UnixFamily, wasi.StreamSocket, wasi.UDPProtocol)
+		assertEqual(t, sock, ^wasi.FD(0))
+		assertEqual(t, errno, wasi.EPROTONOSUPPORT)
+	},
+
+	"cannot create a unix stream socket with the tcp protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		sock, errno := sockOpen(t, ctx, sys, wasi.UnixFamily, wasi.StreamSocket, wasi.TCPProtocol)
+		assertEqual(t, sock, ^wasi.FD(0))
+		assertEqual(t, errno, wasi.EPROTONOSUPPORT)
+	},
+
+	"cannot create a unix datagram socket with the udp protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		sock, errno := sockOpen(t, ctx, sys, wasi.UnixFamily, wasi.DatagramSocket, wasi.UDPProtocol)
+		assertEqual(t, sock, ^wasi.FD(0))
+		assertEqual(t, errno, wasi.EPROTONOSUPPORT)
+	},
+
+	"cannot create a unix datagram socket with the tcp protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		sock, errno := sockOpen(t, ctx, sys, wasi.UnixFamily, wasi.DatagramSocket, wasi.TCPProtocol)
+		assertEqual(t, sock, ^wasi.FD(0))
+		assertEqual(t, errno, wasi.EPROTONOSUPPORT)
+	},
+
+	"tcp sockets for ipv4 are of stream type": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		sock, errno := sockOpen(t, ctx, sys, wasi.InetFamily, wasi.AnySocket, wasi.TCPProtocol)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		opt, errno := sys.SockGetOpt(ctx, sock, wasi.SocketLevel, wasi.QuerySocketType)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		val, ok := opt.(wasi.IntValue)
+		assertEqual(t, ok, true)
+		assertEqual(t, wasi.SocketType(val), wasi.StreamSocket)
+		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
+	},
+
+	"tcp sockets for ipv6 are of stream type": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		sock, errno := sockOpen(t, ctx, sys, wasi.Inet6Family, wasi.AnySocket, wasi.TCPProtocol)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		opt, errno := sys.SockGetOpt(ctx, sock, wasi.SocketLevel, wasi.QuerySocketType)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		val, ok := opt.(wasi.IntValue)
+		assertEqual(t, ok, true)
+		assertEqual(t, wasi.SocketType(val), wasi.StreamSocket)
+		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
+	},
+
+	"udp sockets for ipv4 are of datagram type": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		sock, errno := sockOpen(t, ctx, sys, wasi.InetFamily, wasi.AnySocket, wasi.UDPProtocol)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		opt, errno := sys.SockGetOpt(ctx, sock, wasi.SocketLevel, wasi.QuerySocketType)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		val, ok := opt.(wasi.IntValue)
+		assertEqual(t, ok, true)
+		assertEqual(t, wasi.SocketType(val), wasi.DatagramSocket)
+		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
+	},
+
+	"udp sockets for ipv6 are of datagram type": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		sock, errno := sockOpen(t, ctx, sys, wasi.Inet6Family, wasi.AnySocket, wasi.UDPProtocol)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		opt, errno := sys.SockGetOpt(ctx, sock, wasi.SocketLevel, wasi.QuerySocketType)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		val, ok := opt.(wasi.IntValue)
+		assertEqual(t, ok, true)
+		assertEqual(t, wasi.SocketType(val), wasi.DatagramSocket)
+		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
+	},
+}
+
+func sockOpen(t *testing.T, ctx context.Context, sys wasi.System, family wasi.ProtocolFamily, typ wasi.SocketType, proto wasi.Protocol) (wasi.FD, wasi.Errno) {
+	t.Helper()
+	sock, errno := sys.SockOpen(ctx, family, typ, proto, wasi.AllRights, wasi.AllRights)
+	skipIfNotImplemented(t, errno)
+	return sock, errno
+}

--- a/wasitest/socket.go
+++ b/wasitest/socket.go
@@ -5,124 +5,362 @@ import (
 	"testing"
 
 	"github.com/stealthrocket/wasi-go"
+	"golang.org/x/exp/slices"
+)
+
+var (
+	localIPv4 = [4]byte{127, 0, 0, 1}
+	localIPv6 = [16]byte{15: 1}
+
+	unknownIPv4 = [4]byte{127, 0, 0, 2}
+	unknownIPv6 = [16]byte{15: 2}
 )
 
 var socket = testSuite{
-	"can create a tcp socket for ipv4": func(t *testing.T, ctx context.Context, newSystem newSystem) {
-		sys := newSystem(TestConfig{})
-		sock, errno := sockOpen(t, ctx, sys, wasi.InetFamily, wasi.StreamSocket, wasi.TCPProtocol)
-		assertEqual(t, errno, wasi.ESUCCESS)
-		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
-	},
+	"can create a tcp socket for ipv4": testSocketOpenOK(
+		wasi.InetFamily, wasi.StreamSocket, wasi.TCPProtocol,
+	),
 
-	"can create a udp socket for ipv4": func(t *testing.T, ctx context.Context, newSystem newSystem) {
-		sys := newSystem(TestConfig{})
-		sock, errno := sockOpen(t, ctx, sys, wasi.InetFamily, wasi.DatagramSocket, wasi.UDPProtocol)
-		assertEqual(t, errno, wasi.ESUCCESS)
-		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
-	},
+	"can create a tcp socket for ipv6": testSocketOpenOK(
+		wasi.Inet6Family, wasi.StreamSocket, wasi.TCPProtocol,
+	),
 
-	"can create a tcp socket for ipv6": func(t *testing.T, ctx context.Context, newSystem newSystem) {
-		sys := newSystem(TestConfig{})
-		sock, errno := sockOpen(t, ctx, sys, wasi.Inet6Family, wasi.StreamSocket, wasi.TCPProtocol)
-		assertEqual(t, errno, wasi.ESUCCESS)
-		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
-	},
+	"can create a udp socket for ipv4": testSocketOpenOK(
+		wasi.InetFamily, wasi.DatagramSocket, wasi.UDPProtocol,
+	),
 
-	"can create a udp socket for ipv6": func(t *testing.T, ctx context.Context, newSystem newSystem) {
-		sys := newSystem(TestConfig{})
-		sock, errno := sockOpen(t, ctx, sys, wasi.Inet6Family, wasi.DatagramSocket, wasi.UDPProtocol)
-		assertEqual(t, errno, wasi.ESUCCESS)
-		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
-	},
+	"can create a udp socket for ipv6": testSocketOpenOK(
+		wasi.Inet6Family, wasi.DatagramSocket, wasi.UDPProtocol,
+	),
 
-	"can create a stream socket for ipv4 with the default protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
-		sys := newSystem(TestConfig{})
-		sock, errno := sockOpen(t, ctx, sys, wasi.InetFamily, wasi.StreamSocket, 0)
-		assertEqual(t, errno, wasi.ESUCCESS)
-		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
-	},
+	"can create a stream socket for ipv4 with the default protocol": testSocketOpenOK(
+		wasi.InetFamily, wasi.StreamSocket, 0,
+	),
 
-	"can create a datagram socket for ipv6 with the default protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
-		sys := newSystem(TestConfig{})
-		sock, errno := sockOpen(t, ctx, sys, wasi.InetFamily, wasi.DatagramSocket, 0)
-		assertEqual(t, errno, wasi.ESUCCESS)
-		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
-	},
+	"can create a stream socket for ipv6 with the default protocol": testSocketOpenOK(
+		wasi.Inet6Family, wasi.StreamSocket, 0,
+	),
 
-	"can create a stream socket for unix with the default protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
-		sys := newSystem(TestConfig{})
-		sock, errno := sockOpen(t, ctx, sys, wasi.UnixFamily, wasi.StreamSocket, 0)
-		assertEqual(t, errno, wasi.ESUCCESS)
-		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
-	},
+	"can create a datagram socket for ipv4 with the default protocol": testSocketOpenOK(
+		wasi.InetFamily, wasi.DatagramSocket, 0,
+	),
 
-	"can create a datagram socket for unix with the default protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
-		sys := newSystem(TestConfig{})
-		sock, errno := sockOpen(t, ctx, sys, wasi.UnixFamily, wasi.DatagramSocket, 0)
-		assertEqual(t, errno, wasi.ESUCCESS)
-		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
-	},
+	"can create a datagram socket for ipv6 with the default protocol": testSocketOpenOK(
+		wasi.Inet6Family, wasi.DatagramSocket, 0,
+	),
 
-	"cannot create an ipv4 stream socket with the udp protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
-		sys := newSystem(TestConfig{})
-		sock, errno := sockOpen(t, ctx, sys, wasi.InetFamily, wasi.StreamSocket, wasi.UDPProtocol)
-		assertEqual(t, sock, ^wasi.FD(0))
-		assertEqual(t, errno, wasi.EPROTOTYPE)
-	},
+	"can create a stream socket for unix with the default protocol": testSocketOpenOK(
+		wasi.UnixFamily, wasi.StreamSocket, 0,
+	),
 
-	"cannot create an ipv4 datagram socket with the tcp protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
-		sys := newSystem(TestConfig{})
-		sock, errno := sockOpen(t, ctx, sys, wasi.InetFamily, wasi.DatagramSocket, wasi.TCPProtocol)
-		assertEqual(t, sock, ^wasi.FD(0))
-		assertEqual(t, errno, wasi.EPROTOTYPE)
-	},
+	"cannot create an ipv4 stream socket with the udp protocol": testSocketOpenError(
+		wasi.InetFamily, wasi.StreamSocket, wasi.UDPProtocol, wasi.EPROTOTYPE,
+	),
 
-	"cannot create an ipv6 stream socket with the udp protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
-		sys := newSystem(TestConfig{})
-		sock, errno := sockOpen(t, ctx, sys, wasi.Inet6Family, wasi.StreamSocket, wasi.UDPProtocol)
-		assertEqual(t, sock, ^wasi.FD(0))
-		assertEqual(t, errno, wasi.EPROTOTYPE)
-	},
+	"cannot create an ipv4 datagram socket with the tcp protocol": testSocketOpenError(
+		wasi.InetFamily, wasi.DatagramSocket, wasi.TCPProtocol, wasi.EPROTOTYPE,
+	),
 
-	"cannot create an ipv6 datagram socket with the tcp protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
-		sys := newSystem(TestConfig{})
-		sock, errno := sockOpen(t, ctx, sys, wasi.Inet6Family, wasi.DatagramSocket, wasi.TCPProtocol)
-		assertEqual(t, sock, ^wasi.FD(0))
-		assertEqual(t, errno, wasi.EPROTOTYPE)
-	},
+	"cannot create an ipv6 stream socket with the udp protocol": testSocketOpenError(
+		wasi.Inet6Family, wasi.StreamSocket, wasi.UDPProtocol, wasi.EPROTOTYPE,
+	),
 
-	"cannot create a unix stream socket with the udp protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
-		sys := newSystem(TestConfig{})
-		sock, errno := sockOpen(t, ctx, sys, wasi.UnixFamily, wasi.StreamSocket, wasi.UDPProtocol)
-		assertEqual(t, sock, ^wasi.FD(0))
-		assertEqual(t, errno, wasi.EPROTONOSUPPORT)
-	},
+	"cannot create an ipv6 datagram socket with the tcp protocol": testSocketOpenError(
+		wasi.Inet6Family, wasi.DatagramSocket, wasi.TCPProtocol, wasi.EPROTOTYPE,
+	),
 
-	"cannot create a unix stream socket with the tcp protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
-		sys := newSystem(TestConfig{})
-		sock, errno := sockOpen(t, ctx, sys, wasi.UnixFamily, wasi.StreamSocket, wasi.TCPProtocol)
-		assertEqual(t, sock, ^wasi.FD(0))
-		assertEqual(t, errno, wasi.EPROTONOSUPPORT)
-	},
+	"cannot create a unix stream socket with the tcp protocol": testSocketOpenError(
+		wasi.UnixFamily, wasi.StreamSocket, wasi.TCPProtocol, wasi.EPROTONOSUPPORT,
+	),
 
-	"cannot create a unix datagram socket with the udp protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
-		sys := newSystem(TestConfig{})
-		sock, errno := sockOpen(t, ctx, sys, wasi.UnixFamily, wasi.DatagramSocket, wasi.UDPProtocol)
-		assertEqual(t, sock, ^wasi.FD(0))
-		assertEqual(t, errno, wasi.EPROTONOSUPPORT)
-	},
+	"cannot create a unix stream socket with the udp protocol": testSocketOpenError(
+		wasi.UnixFamily, wasi.StreamSocket, wasi.UDPProtocol, wasi.EPROTONOSUPPORT,
+	),
 
-	"cannot create a unix datagram socket with the tcp protocol": func(t *testing.T, ctx context.Context, newSystem newSystem) {
-		sys := newSystem(TestConfig{})
-		sock, errno := sockOpen(t, ctx, sys, wasi.UnixFamily, wasi.DatagramSocket, wasi.TCPProtocol)
-		assertEqual(t, sock, ^wasi.FD(0))
-		assertEqual(t, errno, wasi.EPROTONOSUPPORT)
-	},
+	"cannot create a unix datagram socket with the tcp protocol": testSocketOpenError(
+		wasi.UnixFamily, wasi.DatagramSocket, wasi.TCPProtocol, wasi.EPROTONOSUPPORT,
+	),
 
-	"tcp sockets for ipv4 are of stream type": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+	"cannot create a unix datagram socket with the udp protocol": testSocketOpenError(
+		wasi.UnixFamily, wasi.DatagramSocket, wasi.UDPProtocol, wasi.EPROTONOSUPPORT,
+	),
+
+	"tcp sockets for ipv4 are of stream type": testSocketType(
+		wasi.InetFamily, wasi.StreamSocket, wasi.TCPProtocol,
+	),
+
+	"tcp sockets for ipv6 are of stream type": testSocketType(
+		wasi.Inet6Family, wasi.StreamSocket, wasi.TCPProtocol,
+	),
+
+	"udp sockets for ipv4 are of datagram type": testSocketType(
+		wasi.InetFamily, wasi.DatagramSocket, wasi.UDPProtocol,
+	),
+
+	"udp sockets for ipv6 are of datagram type": testSocketType(
+		wasi.Inet6Family, wasi.DatagramSocket, wasi.UDPProtocol,
+	),
+
+	"bind an ipv4 stream socket to a port selects that port": testSocketBindOK(
+		wasi.InetFamily, wasi.StreamSocket, &wasi.Inet4Address{Addr: localIPv4, Port: 41200},
+	),
+
+	"bind an ipv4 datagram socket to a port selects that port": testSocketBindOK(
+		wasi.InetFamily, wasi.DatagramSocket, &wasi.Inet4Address{Addr: localIPv4, Port: 41201},
+	),
+
+	"bind an ipv6 stream socket to a port selects that port": testSocketBindOK(
+		wasi.Inet6Family, wasi.StreamSocket, &wasi.Inet6Address{Addr: localIPv6, Port: 41202},
+	),
+
+	"bind an ipv6 datagram socket to a port selects that port": testSocketBindOK(
+		wasi.Inet6Family, wasi.DatagramSocket, &wasi.Inet6Address{Addr: localIPv6, Port: 41203},
+	),
+
+	"bind an ipv4 stream socket to port zero selects a random port": testSocketBindOK(
+		wasi.InetFamily, wasi.StreamSocket, &wasi.Inet4Address{Addr: localIPv4},
+	),
+
+	"bind an ipv4 datagram socket to port zero selects a random port": testSocketBindOK(
+		wasi.InetFamily, wasi.DatagramSocket, &wasi.Inet4Address{Addr: localIPv4},
+	),
+
+	"bind an ipv6 stream socket to port zero selects a random port": testSocketBindOK(
+		wasi.Inet6Family, wasi.StreamSocket, &wasi.Inet6Address{Addr: localIPv6},
+	),
+
+	"bind an ipv6 datagram socket to port zero selects a random port": testSocketBindOK(
+		wasi.Inet6Family, wasi.DatagramSocket, &wasi.Inet6Address{Addr: localIPv6},
+	),
+
+	"bind an ipv4 stream socket to address zero selects any address": testSocketBindOK(
+		wasi.InetFamily, wasi.StreamSocket, &wasi.Inet4Address{},
+	),
+
+	"bind an ipv4 datagram socket to address zero selects any address": testSocketBindOK(
+		wasi.InetFamily, wasi.DatagramSocket, &wasi.Inet4Address{},
+	),
+
+	"bind an ipv6 stream socket to address zero selects any address": testSocketBindOK(
+		wasi.Inet6Family, wasi.StreamSocket, &wasi.Inet6Address{},
+	),
+
+	"bind an ipv6 datagram socket to address zero selects any address": testSocketBindOK(
+		wasi.Inet6Family, wasi.DatagramSocket, &wasi.Inet6Address{},
+	),
+
+	"cannot bind an ipv4 stream socket to an address which does not exist": testSocketBindError(
+		wasi.InetFamily, wasi.StreamSocket, &wasi.Inet4Address{Addr: unknownIPv4}, wasi.EADDRNOTAVAIL,
+	),
+
+	"cannot bind an ipv4 datagram socket to an address which does not exist": testSocketBindError(
+		wasi.InetFamily, wasi.DatagramSocket, &wasi.Inet4Address{Addr: unknownIPv4}, wasi.EADDRNOTAVAIL,
+	),
+
+	"cannot bind an ipv6 stream socket to an address which does not exist": testSocketBindError(
+		wasi.Inet6Family, wasi.StreamSocket, &wasi.Inet6Address{Addr: unknownIPv6}, wasi.EADDRNOTAVAIL,
+	),
+
+	"cannot bind an ipv6 datagram socket to an address which does not exist": testSocketBindError(
+		wasi.Inet6Family, wasi.DatagramSocket, &wasi.Inet6Address{Addr: unknownIPv6}, wasi.EADDRNOTAVAIL,
+	),
+
+	"cannot bind an ipv4 stream socket to a port which does not exist": testSocketBindError(
+		wasi.InetFamily, wasi.StreamSocket, &wasi.Inet4Address{Addr: localIPv4, Port: -1}, wasi.EINVAL,
+	),
+
+	"cannot bind an ipv4 datagram socket to a port which does not exist": testSocketBindError(
+		wasi.InetFamily, wasi.DatagramSocket, &wasi.Inet4Address{Addr: localIPv4, Port: -1}, wasi.EINVAL,
+	),
+
+	"cannot bind an ipv6 stream socket to a port which does not exist": testSocketBindError(
+		wasi.Inet6Family, wasi.StreamSocket, &wasi.Inet6Address{Addr: localIPv6, Port: -1}, wasi.EINVAL,
+	),
+
+	"cannot bind an ipv6 datagram socket to a port which does not exist": testSocketBindError(
+		wasi.Inet6Family, wasi.DatagramSocket, &wasi.Inet6Address{Addr: localIPv6, Port: -1}, wasi.EINVAL,
+	),
+
+	"cannot bind an ipv4 stream socket that was already bound": testSocketBindAfterBind(
+		wasi.InetFamily, wasi.StreamSocket,
+		&wasi.Inet4Address{Addr: localIPv4},
+		&wasi.Inet4Address{Addr: localIPv4},
+	),
+
+	"cannot bind an ipv6 stream socket that was already bound": testSocketBindAfterBind(
+		wasi.Inet6Family, wasi.StreamSocket,
+		&wasi.Inet6Address{Addr: localIPv6},
+		&wasi.Inet6Address{Addr: localIPv6},
+	),
+
+	"cannot bind an ipv4 datagram socket that was already bound": testSocketBindAfterBind(
+		wasi.InetFamily, wasi.DatagramSocket,
+		&wasi.Inet4Address{Addr: localIPv4},
+		&wasi.Inet4Address{Addr: localIPv4},
+	),
+
+	"cannot bind an ipv6 datagram socket that was already bound": testSocketBindAfterBind(
+		wasi.Inet6Family, wasi.DatagramSocket,
+		&wasi.Inet6Address{Addr: localIPv6},
+		&wasi.Inet6Address{Addr: localIPv6},
+	),
+
+	"cannot bind an ipv4 datagram socket that was already connected": testSocketBindAfterConnect(
+		wasi.InetFamily, wasi.DatagramSocket,
+		&wasi.Inet4Address{Addr: localIPv4, Port: 53},
+		&wasi.Inet4Address{Addr: localIPv4},
+	),
+
+	"cannot bind an ipv6 datagram socket that was already connected": testSocketBindAfterConnect(
+		wasi.Inet6Family, wasi.DatagramSocket,
+		&wasi.Inet6Address{Addr: localIPv6, Port: 53},
+		&wasi.Inet6Address{Addr: localIPv6},
+	),
+
+	"can listen on ipv4 stream sockets": testSocketListenOK(
+		wasi.InetFamily, wasi.StreamSocket, &wasi.Inet4Address{Addr: localIPv4},
+	),
+
+	"can listen on ipv6 stream sockets": testSocketListenOK(
+		wasi.Inet6Family, wasi.StreamSocket, &wasi.Inet6Address{Addr: localIPv6},
+	),
+
+	"can connect two ipv4 stream sockets": testSocketConnectAndAccept(
+		wasi.InetFamily, wasi.StreamSocket, &wasi.Inet4Address{Addr: localIPv4},
+	),
+
+	"can connect two ipv6 stream sockets": testSocketConnectAndAccept(
+		wasi.Inet6Family, wasi.StreamSocket, &wasi.Inet6Address{Addr: localIPv6},
+	),
+
+	"can connect a ipv4 datagram socket": testSocketConnectOK(
+		wasi.InetFamily, wasi.DatagramSocket, &wasi.Inet4Address{Addr: localIPv4, Port: 53},
+	),
+
+	"can connect a ipv6 datagram socket": testSocketConnectOK(
+		wasi.Inet6Family, wasi.DatagramSocket, &wasi.Inet6Address{Addr: localIPv6, Port: 53},
+	),
+
+	"cannot connect a listening ipv4 socket": testSocketConnectAfterListen(
+		wasi.InetFamily, wasi.StreamSocket, &wasi.Inet4Address{Addr: localIPv4},
+	),
+
+	"cannot connect a listening ipv6 socket": testSocketConnectAfterListen(
+		wasi.Inet6Family, wasi.StreamSocket, &wasi.Inet6Address{Addr: localIPv6},
+	),
+
+	"cannot shutdown an ipv4 stream socket with an invalid argument": testSocketShutdownInvalidArgument(
+		wasi.InetFamily, wasi.StreamSocket,
+	),
+
+	"cannot shutdown an ipv6 stream socket with an invalid argument": testSocketShutdownInvalidArgument(
+		wasi.Inet6Family, wasi.StreamSocket,
+	),
+
+	"cannot shutdown an ipv4 datagram socket with an invalid argument": testSocketShutdownInvalidArgument(
+		wasi.InetFamily, wasi.DatagramSocket,
+	),
+
+	"cannot shutdown an ipv6 datagram socket with an invalid argument": testSocketShutdownInvalidArgument(
+		wasi.Inet6Family, wasi.DatagramSocket,
+	),
+
+	"cannot shutdown an ipv4 stream socket which is not connected": testSocketShutdownBeforeConnect(
+		wasi.InetFamily, wasi.StreamSocket,
+	),
+
+	"cannot shutdown an ipv6 stream socket which is not connected": testSocketShutdownBeforeConnect(
+		wasi.Inet6Family, wasi.StreamSocket,
+	),
+
+	"cannot shutdown an ipv4 datagram socket which is not connected": testSocketShutdownBeforeConnect(
+		wasi.InetFamily, wasi.DatagramSocket,
+	),
+
+	"cannot shutdown an ipv6 datagram socket which is not connected": testSocketShutdownBeforeConnect(
+		wasi.Inet6Family, wasi.DatagramSocket,
+	),
+
+	"cannot shutdown an ipv4 stream socket which is listening": testSocketShutdownAfterListen(
+		wasi.InetFamily, wasi.StreamSocket, &wasi.Inet4Address{Addr: localIPv4},
+	),
+
+	"cannot shutdown an ipv6 stream socket which is listening": testSocketShutdownAfterListen(
+		wasi.Inet6Family, wasi.StreamSocket, &wasi.Inet6Address{Addr: localIPv6},
+	),
+
+	"can shutdown ipv4 stream socket after accepting": testSocketConnectAndShutdown(
+		wasi.InetFamily, wasi.StreamSocket, &wasi.Inet4Address{Addr: localIPv4},
+	),
+
+	"cannot bind a file descriptor which is not a socket": testNotSocket(
+		func(ctx context.Context, sys wasi.System, fd wasi.FD) wasi.Errno {
+			_, errno := sys.SockBind(ctx, fd, &wasi.Inet4Address{Addr: localIPv4})
+			return errno
+		},
+	),
+
+	"cannot listen on a file descriptor which is not a socket": testNotSocket(
+		func(ctx context.Context, sys wasi.System, fd wasi.FD) wasi.Errno {
+			return sys.SockListen(ctx, fd, 0)
+		},
+	),
+
+	"cannot receive on a file descriptor which is not a socket": testNotSocket(
+		func(ctx context.Context, sys wasi.System, fd wasi.FD) wasi.Errno {
+			_, _, errno := sys.SockRecv(ctx, fd, []wasi.IOVec{nil}, 0)
+			return errno
+		},
+	),
+
+	"cannot send on a file descriptor which is not a socket": testNotSocket(
+		func(ctx context.Context, sys wasi.System, fd wasi.FD) wasi.Errno {
+			_, errno := sys.SockSend(ctx, fd, []wasi.IOVec{nil}, 0)
+			return errno
+		},
+	),
+
+	"cannot shutdown a file descriptor which is not a socket": testNotSocket(
+		func(ctx context.Context, sys wasi.System, fd wasi.FD) wasi.Errno {
+			return sys.SockShutdown(ctx, fd, wasi.ShutdownRD|wasi.ShutdownWR)
+		},
+	),
+
+	"cannot accept on a file descriptor which is not a socket": testNotSocket(
+		func(ctx context.Context, sys wasi.System, fd wasi.FD) wasi.Errno {
+			_, _, _, errno := sys.SockAccept(ctx, fd, 0)
+			return errno
+		},
+	),
+
+	"cannot get socket options on a file descriptor which is not a socket": testNotSocket(
+		func(ctx context.Context, sys wasi.System, fd wasi.FD) wasi.Errno {
+			_, errno := sys.SockGetOpt(ctx, fd, wasi.SocketLevel, wasi.QuerySocketType)
+			return errno
+		},
+	),
+
+	"cannot set socket options on a file descriptor which is not a socket": testNotSocket(
+		func(ctx context.Context, sys wasi.System, fd wasi.FD) wasi.Errno {
+			return sys.SockSetOpt(ctx, fd, wasi.SocketLevel, wasi.SendBufferSize, wasi.IntValue(4096))
+		},
+	),
+}
+
+func testNotSocket(test func(context.Context, wasi.System, wasi.FD) wasi.Errno) testFunc {
+	return func(t *testing.T, ctx context.Context, newSystem newSystem) {
 		sys := newSystem(TestConfig{})
-		sock, errno := sockOpen(t, ctx, sys, wasi.InetFamily, wasi.AnySocket, wasi.TCPProtocol)
+		assertEqual(t, test(ctx, sys, 0), wasi.ENOTSOCK)
+		assertEqual(t, test(ctx, sys, 1), wasi.ENOTSOCK)
+		assertEqual(t, test(ctx, sys, 2), wasi.ENOTSOCK)
+	}
+}
+
+func testSocketType(family wasi.ProtocolFamily, typ wasi.SocketType, proto wasi.Protocol) testFunc {
+	return func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+
+		sock, errno := sockOpen(t, ctx, sys, family, wasi.AnySocket, proto)
 		assertEqual(t, errno, wasi.ESUCCESS)
 
 		opt, errno := sys.SockGetOpt(ctx, sock, wasi.SocketLevel, wasi.QuerySocketType)
@@ -130,66 +368,399 @@ var socket = testSuite{
 
 		val, ok := opt.(wasi.IntValue)
 		assertEqual(t, ok, true)
-		assertEqual(t, wasi.SocketType(val), wasi.StreamSocket)
+		assertEqual(t, wasi.SocketType(val), typ)
 		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
-	},
+	}
+}
 
-	"tcp sockets for ipv6 are of stream type": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+func testSocketOpenOK(family wasi.ProtocolFamily, typ wasi.SocketType, proto wasi.Protocol) testFunc {
+	return func(t *testing.T, ctx context.Context, newSystem newSystem) {
 		sys := newSystem(TestConfig{})
-		sock, errno := sockOpen(t, ctx, sys, wasi.Inet6Family, wasi.AnySocket, wasi.TCPProtocol)
+		sock, errno := sockOpen(t, ctx, sys, family, typ, proto)
 		assertEqual(t, errno, wasi.ESUCCESS)
-
-		opt, errno := sys.SockGetOpt(ctx, sock, wasi.SocketLevel, wasi.QuerySocketType)
-		assertEqual(t, errno, wasi.ESUCCESS)
-
-		val, ok := opt.(wasi.IntValue)
-		assertEqual(t, ok, true)
-		assertEqual(t, wasi.SocketType(val), wasi.StreamSocket)
 		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
-	},
+	}
+}
 
-	"udp sockets for ipv4 are of datagram type": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+func testSocketOpenError(family wasi.ProtocolFamily, typ wasi.SocketType, proto wasi.Protocol, want wasi.Errno) testFunc {
+	return func(t *testing.T, ctx context.Context, newSystem newSystem) {
 		sys := newSystem(TestConfig{})
-		sock, errno := sockOpen(t, ctx, sys, wasi.InetFamily, wasi.AnySocket, wasi.UDPProtocol)
-		assertEqual(t, errno, wasi.ESUCCESS)
+		sock, errno := sockOpen(t, ctx, sys, family, typ, proto)
+		assertEqual(t, sock, ^wasi.FD(0))
+		assertEqual(t, errno, want)
+	}
+}
 
-		opt, errno := sys.SockGetOpt(ctx, sock, wasi.SocketLevel, wasi.QuerySocketType)
-		assertEqual(t, errno, wasi.ESUCCESS)
-
-		val, ok := opt.(wasi.IntValue)
-		assertEqual(t, ok, true)
-		assertEqual(t, wasi.SocketType(val), wasi.DatagramSocket)
-		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
-	},
-
-	"udp sockets for ipv6 are of datagram type": func(t *testing.T, ctx context.Context, newSystem newSystem) {
+func testSocketBindOK(family wasi.ProtocolFamily, typ wasi.SocketType, bind wasi.SocketAddress) testFunc {
+	return func(t *testing.T, ctx context.Context, newSystem newSystem) {
 		sys := newSystem(TestConfig{})
-		sock, errno := sockOpen(t, ctx, sys, wasi.Inet6Family, wasi.AnySocket, wasi.UDPProtocol)
+
+		sock, errno := sockOpen(t, ctx, sys, family, typ, 0)
 		assertEqual(t, errno, wasi.ESUCCESS)
 
-		opt, errno := sys.SockGetOpt(ctx, sock, wasi.SocketLevel, wasi.QuerySocketType)
+		addr, errno := sys.SockBind(ctx, sock, bind)
 		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, addr.Family(), bind.Family())
 
-		val, ok := opt.(wasi.IntValue)
-		assertEqual(t, ok, true)
-		assertEqual(t, wasi.SocketType(val), wasi.DatagramSocket)
+		switch a := addr.(type) {
+		case *wasi.Inet4Address:
+			b := bind.(*wasi.Inet4Address)
+			assertEqual(t, a.Addr, b.Addr)
+			if b.Port == 0 {
+				assertNotEqual(t, a.Port, 0)
+			} else {
+				assertEqual(t, a.Port, b.Port)
+			}
+		case *wasi.Inet6Address:
+			b := bind.(*wasi.Inet6Address)
+			assertEqual(t, a.Addr, b.Addr)
+			if b.Port == 0 {
+				assertNotEqual(t, a.Port, 0)
+			} else {
+				assertEqual(t, a.Port, b.Port)
+			}
+		default:
+			t.Errorf("socket bound to address of unknown type %T", a)
+		}
+
 		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
-	},
+	}
+}
+
+func testSocketBindError(family wasi.ProtocolFamily, typ wasi.SocketType, bind wasi.SocketAddress, want wasi.Errno) testFunc {
+	return func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+
+		sock, errno := sockOpen(t, ctx, sys, family, typ, 0)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		addr, errno := sys.SockBind(ctx, sock, bind)
+		assertEqual(t, addr, nil)
+		assertEqual(t, errno, want)
+		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
+	}
+}
+
+func testSocketListenOK(family wasi.ProtocolFamily, typ wasi.SocketType, bind wasi.SocketAddress) testFunc {
+	return func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+
+		sock, errno := sockOpen(t, ctx, sys, family, typ, 0)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		_, errno = sys.SockBind(ctx, sock, bind)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, sys.SockListen(ctx, sock, 10), wasi.ESUCCESS)
+		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
+	}
+}
+
+func testSocketConnectOK(family wasi.ProtocolFamily, typ wasi.SocketType, bind wasi.SocketAddress) testFunc {
+	return func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+
+		sock, errno := sockOpen(t, ctx, sys, family, typ, 0)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		addr, errno := sys.SockConnect(ctx, sock, bind)
+		assertNotEqual(t, addr, nil)
+		assertEqual(t, addr.Family(), bind.Family())
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		if errno != wasi.ESUCCESS {
+			assertEqual(t, errno, wasi.EINPROGRESS)
+		}
+
+		subs := []wasi.Subscription{
+			wasi.MakeSubscriptionFDReadWrite(42, wasi.FDWriteEvent, wasi.SubscriptionFDReadWrite{
+				FD: sock,
+			}),
+		}
+		evs := make([]wasi.Event, len(subs))
+
+		numEvents, errno := sys.PollOneOff(ctx, subs, evs)
+		assertEqual(t, numEvents, 1)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		assertEqual(t, evs[0], wasi.Event{
+			UserData:    42,
+			EventType:   wasi.FDWriteEvent,
+			FDReadWrite: wasi.EventFDReadWrite{NBytes: 1},
+		})
+	}
+}
+
+func testSocketConnectAndAccept(family wasi.ProtocolFamily, typ wasi.SocketType, bind wasi.SocketAddress) testFunc {
+	return func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+
+		server, errno := sockOpen(t, ctx, sys, family, typ, 0)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		serverAddr, errno := sys.SockBind(ctx, server, bind)
+		assertNotEqual(t, serverAddr, nil)
+		assertEqual(t, serverAddr.Family(), bind.Family())
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, sys.SockListen(ctx, server, 0), wasi.ESUCCESS)
+
+		client, errno := sockOpen(t, ctx, sys, family, typ, 0)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		clientAddr, errno := sys.SockConnect(ctx, client, serverAddr)
+		assertNotEqual(t, clientAddr, nil)
+		assertEqual(t, clientAddr.Family(), bind.Family())
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		if errno != wasi.ESUCCESS {
+			assertEqual(t, errno, wasi.EINPROGRESS)
+		}
+
+		subs := []wasi.Subscription{
+			wasi.MakeSubscriptionFDReadWrite(1, wasi.FDReadEvent, wasi.SubscriptionFDReadWrite{
+				FD: server,
+			}),
+			wasi.MakeSubscriptionFDReadWrite(2, wasi.FDWriteEvent, wasi.SubscriptionFDReadWrite{
+				FD: client,
+			}),
+		}
+		evs := make([]wasi.Event, len(subs))
+
+		numEvents, errno := sys.PollOneOff(ctx, subs, evs)
+		assertEqual(t, numEvents, 2)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		sortEvents(evs[:numEvents])
+		assertEqual(t, evs[0], wasi.Event{
+			UserData:    1,
+			EventType:   wasi.FDReadEvent,
+			FDReadWrite: wasi.EventFDReadWrite{NBytes: 1},
+		})
+		assertEqual(t, evs[1], wasi.Event{
+			UserData:    2,
+			EventType:   wasi.FDWriteEvent,
+			FDReadWrite: wasi.EventFDReadWrite{NBytes: 1},
+		})
+
+		accept, remoteAddr, localAddr, errno := sys.SockAccept(ctx, server, wasi.NonBlock)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertNotEqual(t, accept, ^wasi.FD(0))
+		assertDeepEqual(t, localAddr, serverAddr)
+		assertDeepEqual(t, remoteAddr, clientAddr)
+
+		localAddr, errno = sys.SockLocalAddress(ctx, accept)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertDeepEqual(t, localAddr, serverAddr)
+
+		remoteAddr, errno = sys.SockRemoteAddress(ctx, accept)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertDeepEqual(t, remoteAddr, clientAddr)
+
+		assertEqual(t, sys.FDClose(ctx, accept), wasi.ESUCCESS)
+		assertEqual(t, sys.FDClose(ctx, client), wasi.ESUCCESS)
+		assertEqual(t, sys.FDClose(ctx, server), wasi.ESUCCESS)
+	}
+}
+
+func testSocketConnectAndShutdown(family wasi.ProtocolFamily, typ wasi.SocketType, bind wasi.SocketAddress) testFunc {
+	return func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+
+		server, errno := sockOpen(t, ctx, sys, family, typ, 0)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		addr, errno := sys.SockBind(ctx, server, bind)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, sys.SockListen(ctx, server, 0), wasi.ESUCCESS)
+
+		client, errno := sockOpen(t, ctx, sys, family, typ, 0)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		_, errno = sys.SockConnect(ctx, client, addr)
+		if errno != wasi.ESUCCESS {
+			assertEqual(t, errno, wasi.EINPROGRESS)
+		}
+
+		subs := []wasi.Subscription{
+			wasi.MakeSubscriptionFDReadWrite(1, wasi.FDReadEvent, wasi.SubscriptionFDReadWrite{
+				FD: server,
+			}),
+			wasi.MakeSubscriptionFDReadWrite(2, wasi.FDWriteEvent, wasi.SubscriptionFDReadWrite{
+				FD: client,
+			}),
+		}
+		evs := make([]wasi.Event, len(subs))
+
+		numEvents, errno := sys.PollOneOff(ctx, subs, evs)
+		assertEqual(t, numEvents, 2)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		sortEvents(evs[:numEvents])
+		assertEqual(t, evs[0], wasi.Event{
+			UserData:    1,
+			EventType:   wasi.FDReadEvent,
+			FDReadWrite: wasi.EventFDReadWrite{NBytes: 1},
+		})
+		assertEqual(t, evs[1], wasi.Event{
+			UserData:    2,
+			EventType:   wasi.FDWriteEvent,
+			FDReadWrite: wasi.EventFDReadWrite{NBytes: 1},
+		})
+
+		accept, _, _, errno := sys.SockAccept(ctx, server, wasi.NonBlock)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, sys.SockShutdown(ctx, accept, wasi.ShutdownWR), wasi.ESUCCESS)
+		assertEqual(t, sys.SockShutdown(ctx, accept, wasi.ShutdownWR), wasi.ENOTCONN)
+
+		subs = []wasi.Subscription{
+			wasi.MakeSubscriptionFDReadWrite(1, wasi.FDReadEvent, wasi.SubscriptionFDReadWrite{
+				FD: client,
+			}),
+		}
+		numEvents, errno = sys.PollOneOff(ctx, subs, evs)
+		assertEqual(t, numEvents, 1)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, evs[0], wasi.Event{
+			UserData:    1,
+			EventType:   wasi.FDReadEvent,
+			FDReadWrite: wasi.EventFDReadWrite{Flags: wasi.Hangup},
+		})
+
+		assertEqual(t, sys.SockShutdown(ctx, client, wasi.ShutdownRD), wasi.ENOTCONN)
+		assertEqual(t, sys.SockShutdown(ctx, client, wasi.ShutdownWR), wasi.ESUCCESS)
+		assertEqual(t, sys.SockShutdown(ctx, client, wasi.ShutdownWR), wasi.ENOTCONN)
+
+		subs = []wasi.Subscription{
+			wasi.MakeSubscriptionFDReadWrite(1, wasi.FDReadEvent, wasi.SubscriptionFDReadWrite{
+				FD: accept,
+			}),
+		}
+		numEvents, errno = sys.PollOneOff(ctx, subs, evs)
+		assertEqual(t, numEvents, 1)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, evs[0], wasi.Event{
+			UserData:    1,
+			EventType:   wasi.FDReadEvent,
+			FDReadWrite: wasi.EventFDReadWrite{Flags: wasi.Hangup},
+		})
+
+		assertEqual(t, sockErrno(t, ctx, sys, client), wasi.ESUCCESS)
+		assertEqual(t, sockErrno(t, ctx, sys, accept), wasi.ESUCCESS)
+
+		assertEqual(t, sys.FDClose(ctx, accept), wasi.ESUCCESS)
+		assertEqual(t, sys.FDClose(ctx, client), wasi.ESUCCESS)
+		assertEqual(t, sys.FDClose(ctx, server), wasi.ESUCCESS)
+	}
+}
+
+func testSocketBindAfterBind(family wasi.ProtocolFamily, typ wasi.SocketType, bind1, bind2 wasi.SocketAddress) testFunc {
+	return func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+
+		sock, errno := sockOpen(t, ctx, sys, family, typ, 0)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		_, errno = sys.SockBind(ctx, sock, bind1)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		_, errno = sys.SockBind(ctx, sock, bind2)
+		assertEqual(t, errno, wasi.EINVAL)
+
+		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
+	}
+}
+
+func testSocketBindAfterConnect(family wasi.ProtocolFamily, typ wasi.SocketType, bind1, bind2 wasi.SocketAddress) testFunc {
+	return func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+
+		sock, errno := sockOpen(t, ctx, sys, family, typ, 0)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		_, errno = sys.SockConnect(ctx, sock, bind1)
+		if errno != wasi.ESUCCESS {
+			assertEqual(t, errno, wasi.EINPROGRESS)
+		}
+
+		_, errno = sys.SockBind(ctx, sock, bind2)
+		assertEqual(t, errno, wasi.EINVAL)
+
+		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
+	}
+}
+
+func testSocketConnectAfterListen(family wasi.ProtocolFamily, typ wasi.SocketType, bind wasi.SocketAddress) testFunc {
+	return func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+
+		sock, errno := sockOpen(t, ctx, sys, family, typ, 0)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		_, errno = sys.SockBind(ctx, sock, bind)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, sys.SockListen(ctx, sock, 10), wasi.ESUCCESS)
+
+		_, errno = sys.SockConnect(ctx, sock, bind)
+		assertEqual(t, errno, wasi.ENOTSUP)
+
+		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
+	}
+}
+
+func testSocketShutdownInvalidArgument(family wasi.ProtocolFamily, typ wasi.SocketType) testFunc {
+	return func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		sock, errno := sockOpen(t, ctx, sys, family, typ, 0)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, sys.SockShutdown(ctx, sock, ^(wasi.ShutdownRD|wasi.ShutdownWR)), wasi.EINVAL)
+		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
+	}
+}
+
+func testSocketShutdownBeforeConnect(family wasi.ProtocolFamily, typ wasi.SocketType) testFunc {
+	return func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		sock, errno := sockOpen(t, ctx, sys, family, typ, 0)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, sys.SockShutdown(ctx, sock, wasi.ShutdownRD|wasi.ShutdownWR), wasi.ENOTCONN)
+		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
+	}
+}
+
+func testSocketShutdownAfterListen(family wasi.ProtocolFamily, typ wasi.SocketType, bind wasi.SocketAddress) testFunc {
+	return func(t *testing.T, ctx context.Context, newSystem newSystem) {
+		sys := newSystem(TestConfig{})
+		sock, errno := sockOpen(t, ctx, sys, family, typ, 0)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		_, errno = sys.SockBind(ctx, sock, bind)
+		assertEqual(t, errno, wasi.ESUCCESS)
+		assertEqual(t, sys.SockListen(ctx, sock, 0), wasi.ESUCCESS)
+
+		assertEqual(t, sys.SockShutdown(ctx, sock, wasi.ShutdownRD|wasi.ShutdownWR), wasi.ENOTCONN)
+		assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
+	}
 }
 
 func sockOpen(t *testing.T, ctx context.Context, sys wasi.System, family wasi.ProtocolFamily, typ wasi.SocketType, proto wasi.Protocol) (wasi.FD, wasi.Errno) {
 	t.Helper()
 	sock, errno := sys.SockOpen(ctx, family, typ, proto, wasi.AllRights, wasi.AllRights)
 	skipIfNotImplemented(t, errno)
-
 	if errno == wasi.ESUCCESS {
-		opt, errno := sys.SockGetOpt(ctx, sock, wasi.SocketLevel, wasi.QuerySocketError)
-		assertEqual(t, errno, wasi.ESUCCESS)
-
-		val, ok := opt.(wasi.IntValue)
-		assertEqual(t, ok, true)
-		assertEqual(t, wasi.Errno(val), wasi.ESUCCESS)
+		assertEqual(t, sockErrno(t, ctx, sys, sock), wasi.ESUCCESS)
 	}
-
 	return sock, errno
+}
+
+func sockErrno(t *testing.T, ctx context.Context, sys wasi.System, sock wasi.FD) wasi.Errno {
+	opt, errno := sys.SockGetOpt(ctx, sock, wasi.SocketLevel, wasi.QuerySocketError)
+	assertEqual(t, errno, wasi.ESUCCESS)
+	val, ok := opt.(wasi.IntValue)
+	assertEqual(t, ok, true)
+	return wasi.Errno(val)
+}
+
+func sortEvents(events []wasi.Event) {
+	slices.SortFunc(events, func(e1, e2 wasi.Event) bool {
+		return e1.UserData < e2.UserData
+	})
 }

--- a/wasitest/system.go
+++ b/wasitest/system.go
@@ -45,20 +45,22 @@ func (tests testSuite) run(t *testing.T, makeSystem MakeSystem) {
 			defer cancel()
 
 			tests[name](t, ctx, func(c TestConfig) wasi.System {
-				devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
-				if err != nil {
-					t.Fatal(err)
+				devNull := func(flag int) *os.File {
+					f, err := os.OpenFile(os.DevNull, flag, 0)
+					if err != nil {
+						t.Fatal(err)
+					}
+					return f
 				}
-				defer devNull.Close()
 
 				if c.Stdin == nil {
-					c.Stdin = devNull
+					c.Stdin = devNull(os.O_RDONLY)
 				}
 				if c.Stdout == nil {
-					c.Stdout = devNull
+					c.Stdout = devNull(os.O_WRONLY)
 				}
 				if c.Stderr == nil {
-					c.Stderr = devNull
+					c.Stderr = devNull(os.O_WRONLY)
 				}
 
 				s, err := makeSystem(c)

--- a/wasitest/system.go
+++ b/wasitest/system.go
@@ -2,7 +2,6 @@ package wasitest
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/stealthrocket/wasi-go"
@@ -45,24 +44,6 @@ func (tests testSuite) run(t *testing.T, makeSystem MakeSystem) {
 			defer cancel()
 
 			tests[name](t, ctx, func(c TestConfig) wasi.System {
-				devNull := func(flag int) *os.File {
-					f, err := os.OpenFile(os.DevNull, flag, 0)
-					if err != nil {
-						t.Fatal(err)
-					}
-					return f
-				}
-
-				if c.Stdin == nil {
-					c.Stdin = devNull(os.O_RDONLY)
-				}
-				if c.Stdout == nil {
-					c.Stdout = devNull(os.O_WRONLY)
-				}
-				if c.Stderr == nil {
-					c.Stderr = devNull(os.O_WRONLY)
-				}
-
 				s, err := makeSystem(c)
 				if err != nil {
 					t.Fatalf("system initialization failed: %s", err)

--- a/wasitest/system.go
+++ b/wasitest/system.go
@@ -15,6 +15,7 @@ import (
 func TestSystem(t *testing.T, makeSystem MakeSystem) {
 	t.Run("proc", proc.runFunc(makeSystem))
 	t.Run("poll", poll.runFunc(makeSystem))
+	t.Run("socket", socket.runFunc(makeSystem))
 }
 
 type skip string

--- a/wasitest/system.go
+++ b/wasitest/system.go
@@ -1,0 +1,76 @@
+package wasitest
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stealthrocket/wasi-go"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+)
+
+// TestSystem is a test suite which validates the behavior of wasi.System
+// implementations.
+func TestSystem(t *testing.T, makeSystem MakeSystem) {
+	t.Run("proc", proc.runFunc(makeSystem))
+	t.Run("poll", poll.runFunc(makeSystem))
+}
+
+type skip string
+
+func (err skip) Error() string { return string(err) }
+
+type newSystem func(TestConfig) wasi.System
+
+type testFunc func(*testing.T, context.Context, newSystem)
+
+type testSuite map[string]testFunc
+
+func (tests testSuite) names() []string {
+	names := maps.Keys(tests)
+	slices.Sort(names)
+	return names
+}
+
+func (tests testSuite) runFunc(makeSystem MakeSystem) func(*testing.T) {
+	return func(t *testing.T) { tests.run(t, makeSystem) }
+}
+
+func (tests testSuite) run(t *testing.T, makeSystem MakeSystem) {
+	for _, name := range tests.names() {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := testContext(t)
+			defer cancel()
+
+			tests[name](t, ctx, func(c TestConfig) wasi.System {
+				devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer devNull.Close()
+
+				if c.Stdin == nil {
+					c.Stdin = devNull
+				}
+				if c.Stdout == nil {
+					c.Stdout = devNull
+				}
+				if c.Stderr == nil {
+					c.Stderr = devNull
+				}
+
+				s, err := makeSystem(c)
+				if err != nil {
+					t.Fatalf("system initialization failed: %s", err)
+				}
+				t.Cleanup(func() {
+					if err := s.Close(ctx); err != nil {
+						t.Errorf("system closure failed: %s", err)
+					}
+				})
+				return s
+			})
+		})
+	}
+}

--- a/wasitest/wasitest.go
+++ b/wasitest/wasitest.go
@@ -2,6 +2,7 @@ package wasitest
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/stealthrocket/wasi-go"
@@ -25,7 +26,21 @@ func assertOK(t *testing.T, err error) {
 func assertEqual[T comparable](t *testing.T, got, want T) {
 	if got != want {
 		t.Helper()
-		t.Fatalf("%T values mismatch\nwant = %+v\ngot  = %+v", want, want, got)
+		t.Fatalf("%T values must be equal\nwant = %+v\ngot  = %+v", want, want, got)
+	}
+}
+
+func assertNotEqual[T comparable](t *testing.T, got, want T) {
+	if got == want {
+		t.Helper()
+		t.Fatalf("%T values must not be equal\nwant = %+v\ngot  = %+v", want, want, got)
+	}
+}
+
+func assertDeepEqual(t *testing.T, got, want any) {
+	if !reflect.DeepEqual(got, want) {
+		t.Helper()
+		t.Fatalf("%T values must be deep equal\nwant = %+v\ngot  = %+v", want, want, got)
 	}
 }
 

--- a/wasitest/wasitest.go
+++ b/wasitest/wasitest.go
@@ -33,7 +33,7 @@ func assertEqual[T comparable](t *testing.T, got, want T) {
 func assertNotEqual[T comparable](t *testing.T, got, want T) {
 	if got == want {
 		t.Helper()
-		t.Fatalf("%T values must not be equal\nwant = %+v\ngot  = %+v", want, want, got)
+		t.Fatalf("%T values must not be equal\ndo not want = %+v\ngot        = %+v", want, want, got)
 	}
 }
 

--- a/wasitest/wasitest.go
+++ b/wasitest/wasitest.go
@@ -1,0 +1,28 @@
+package wasitest
+
+import (
+	"context"
+	"testing"
+)
+
+func testContext(t *testing.T) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.Background(), func() {}
+	if deadline, ok := t.Deadline(); ok {
+		ctx, cancel = context.WithDeadline(ctx, deadline)
+	}
+	return ctx, cancel
+}
+
+func assertOK(t *testing.T, err error) {
+	if err != nil {
+		t.Helper()
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertEqual[T comparable](t *testing.T, got, want T) {
+	if got != want {
+		t.Helper()
+		t.Fatalf("%T values mismatch\nwant = %+v\ngot  = %+v", want, want, got)
+	}
+}

--- a/wasitest/wasitest.go
+++ b/wasitest/wasitest.go
@@ -3,6 +3,8 @@ package wasitest
 import (
 	"context"
 	"testing"
+
+	"github.com/stealthrocket/wasi-go"
 )
 
 func testContext(t *testing.T) (context.Context, context.CancelFunc) {
@@ -24,5 +26,12 @@ func assertEqual[T comparable](t *testing.T, got, want T) {
 	if got != want {
 		t.Helper()
 		t.Fatalf("%T values mismatch\nwant = %+v\ngot  = %+v", want, want, got)
+	}
+}
+
+func skipIfNotImplemented(t *testing.T, errno wasi.Errno) {
+	if errno == wasi.ENOSYS {
+		t.Helper()
+		t.Skip("operation not implemented on this system")
 	}
 }


### PR DESCRIPTION
This PR adds a test suite for `wasi.System` implementations.

The intent is to have something similar to the `x/net/nettest` or `testing/fstest` test suites to validate the behavior of `wasi.System` in a standalone context (without requiring the help of a guest program). I renamed the `testwasi` package to `wasitest` to follow the naming convention of those test suites.

For now, I have focused on basic process functionality, polling, and socket APIs, especially ensuring that error cases are portable across platforms.

In this process, I encountered a few bugs which are fixed by this code change as well.