### PR TITLE
systems/unix: handle EINTR

### DIFF
--- a/systems/unix/readdir_darwin.go
+++ b/systems/unix/readdir_darwin.go
@@ -35,7 +35,9 @@ func (d *dirbuf) readDirEntries(entries []wasi.DirEntry, cookie wasi.DirCookie, 
 	}
 
 	if cookie < d.cookie {
-		if _, err := syscall.Seek(d.fd, 0, 0); err != nil {
+		if _, err := ignoreEINTR2(func() (int64, error) {
+			return syscall.Seek(d.fd, 0, 0)
+		}); err != nil {
 			return 0, err
 		}
 		d.offset = 0
@@ -54,7 +56,9 @@ func (d *dirbuf) readDirEntries(entries []wasi.DirEntry, cookie wasi.DirCookie, 
 			if numEntries > 0 {
 				return numEntries, nil
 			}
-			n, err := syscall.Getdirentries(d.fd, d.buffer[:], &d.basep)
+			n, err := ignoreEINTR2(func() (int, error) {
+				return syscall.Getdirentries(d.fd, d.buffer[:], &d.basep)
+			})
 			if err != nil {
 				return numEntries, err
 			}

--- a/systems/unix/readdir_linux.go
+++ b/systems/unix/readdir_linux.go
@@ -34,7 +34,9 @@ func (d *dirbuf) readDirEntries(entries []wasi.DirEntry, cookie wasi.DirCookie, 
 	}
 
 	if cookie < d.cookie {
-		if _, err := unix.Seek(d.fd, 0, unix.SEEK_SET); err != nil {
+		if _, err := ignoreEINTR2(func() (int64, error) {
+			return unix.Seek(d.fd, 0, unix.SEEK_SET)
+		}); err != nil {
 			return 0, err
 		}
 		d.offset = 0
@@ -52,7 +54,9 @@ func (d *dirbuf) readDirEntries(entries []wasi.DirEntry, cookie wasi.DirCookie, 
 			if numEntries > 0 {
 				return numEntries, nil
 			}
-			n, err := unix.Getdents(d.fd, d.buffer[:])
+			n, err := ignoreEINTR2(func() (int, error) {
+				return unix.Getdents(d.fd, d.buffer[:])
+			})
 			if err != nil {
 				return numEntries, err
 			}


### PR DESCRIPTION
Based on #58, I noticed that sometimes the tests would fail due to signals interrupting syscalls when repeating tests with `-count`, likely caused by Go's preemptive goroutine scheduling which is based on delivering signals to threads.

The Go stdlib handles EINTR, preventing applications from seeing the error, I believe we should do this as well in the `unix.System` implementation (I left a comment in the code explaining the reasoning for WASI).

