### PR TITLE
unix: consistent unix socket addresses

### DIFF
--- a/systems/unix/system.go
+++ b/systems/unix/system.go
@@ -922,7 +922,15 @@ func (s *System) makeSocketAddress(sa unix.Sockaddr, in4 *wasi.Inet4Address, in6
 		in6.Port = t.Port
 		return in6, true
 	case *unix.SockaddrUnix:
-		un.Name = t.Name
+		if len(t.Name) == 0 {
+			// For consistency across platforms, replace empty unix socket
+			// addresses with @. On Linux, addresses where the first byte is
+			// a null byte are considered abstract unix sockets, and the first
+			// byte is replaced with @.
+			un.Name = "@"
+		} else {
+			un.Name = t.Name
+		}
 		return un, true
 	default:
 		return nil, false


### PR DESCRIPTION
This PR ensures unix socket addresses are consistent across platforms. Only Linux, empty unix socket addresses are seen as `@` because the Go standard library and /x/sys package consider them to be abstract sockets (when the first byte in the address is a null byte). On other platforms, the unix socket address is instead an empty string.