### PR TITLE
wasitest: more socket tests

### DIFF
--- a/wasitest/socket.go
+++ b/wasitest/socket.go
@@ -975,6 +975,12 @@ func testSocketSetBufferSizes(family wasi.ProtocolFamily, typ wasi.SocketType) t
 					assertEqual(t, size, want)
 				})
 
+				t.Run("large socket buffer sizes are capped to a maximum value", func(t *testing.T) {
+					assertEqual(t, sys.SockSetOpt(ctx, sock, wasi.SocketLevel, test.option, wasi.IntValue(math.MaxInt32)), wasi.ENOBUFS)
+					size := getBufferSize()
+					assertNotEqual(t, size, math.MaxInt32)
+				})
+
 				assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
 			})
 		}

--- a/wasitest/socket.go
+++ b/wasitest/socket.go
@@ -968,6 +968,13 @@ func testSocketSetBufferSizes(family wasi.ProtocolFamily, typ wasi.SocketType) t
 					assertEqual(t, size, want)
 				})
 
+				t.Run("cannot set the socket buffer size to a negative value", func(t *testing.T) {
+					want := getBufferSize()
+					assertEqual(t, sys.SockSetOpt(ctx, sock, wasi.SocketLevel, test.option, wasi.IntValue(-1)), wasi.EINVAL)
+					size := getBufferSize()
+					assertEqual(t, size, want)
+				})
+
 				assertEqual(t, sys.FDClose(ctx, sock), wasi.ESUCCESS)
 			})
 		}

--- a/wasitest/socket.go
+++ b/wasitest/socket.go
@@ -357,19 +357,19 @@ var socket = testSuite{
 		wasi.Inet6Family, wasi.StreamSocket,
 	),
 
-	"cannot option of ipv4 stream socket with invalid level": testSocketSetOptionInvalidLevel(
+	"cannot set option of ipv4 stream socket with invalid level": testSocketSetOptionInvalidLevel(
 		wasi.InetFamily, wasi.StreamSocket,
 	),
 
-	"cannot option of ipv6 stream socket with invalid level": testSocketSetOptionInvalidLevel(
+	"cannot set option of ipv6 stream socket with invalid level": testSocketSetOptionInvalidLevel(
 		wasi.Inet6Family, wasi.StreamSocket,
 	),
 
-	"cannot option of ipv4 stream socket with invalid argument": testSocketSetOptionInvalidArgument(
+	"cannot set option of ipv4 stream socket with invalid argument": testSocketSetOptionInvalidArgument(
 		wasi.InetFamily, wasi.StreamSocket,
 	),
 
-	"cannot option of ipv6 stream socket with invalid argument": testSocketSetOptionInvalidArgument(
+	"cannot set option of ipv6 stream socket with invalid argument": testSocketSetOptionInvalidArgument(
 		wasi.Inet6Family, wasi.StreamSocket,
 	),
 

--- a/wasitest/socket.go
+++ b/wasitest/socket.go
@@ -961,22 +961,21 @@ func testSocketSetBufferSizes(family wasi.ProtocolFamily, typ wasi.SocketType) t
 					assertEqual(t, size, want)
 				})
 
-				t.Run("cannot set the socket buffer size to zero", func(t *testing.T) {
-					want := getBufferSize()
-					assertEqual(t, sys.SockSetOpt(ctx, sock, wasi.SocketLevel, test.option, wasi.IntValue(0)), wasi.EINVAL)
-					size := getBufferSize()
-					assertEqual(t, size, want)
-				})
-
-				t.Run("cannot set the socket buffer size to a negative value", func(t *testing.T) {
+				t.Run("negative socket buffer size are fobidden", func(t *testing.T) {
 					want := getBufferSize()
 					assertEqual(t, sys.SockSetOpt(ctx, sock, wasi.SocketLevel, test.option, wasi.IntValue(-1)), wasi.EINVAL)
 					size := getBufferSize()
 					assertEqual(t, size, want)
 				})
 
+				t.Run("small socket buffer sizes are capped to a minimum value", func(t *testing.T) {
+					assertEqual(t, sys.SockSetOpt(ctx, sock, wasi.SocketLevel, test.option, wasi.IntValue(0)), wasi.ESUCCESS)
+					size := getBufferSize()
+					assertNotEqual(t, size, 0)
+				})
+
 				t.Run("large socket buffer sizes are capped to a maximum value", func(t *testing.T) {
-					assertEqual(t, sys.SockSetOpt(ctx, sock, wasi.SocketLevel, test.option, wasi.IntValue(math.MaxInt32)), wasi.ENOBUFS)
+					assertEqual(t, sys.SockSetOpt(ctx, sock, wasi.SocketLevel, test.option, wasi.IntValue(math.MaxInt32)), wasi.ESUCCESS)
 					size := getBufferSize()
 					assertNotEqual(t, size, math.MaxInt32)
 				})


### PR DESCRIPTION
This PR adds more socket tests for better coverage of socket lifecycles and validates greater portability across platforms.