### PR TITLE
wasitest: add tests for sockets in blocking mode

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"time"
 )
 
 // RIFlags are flags provided to SockRecv.
@@ -468,6 +469,15 @@ func (IntValue) sockopt() {}
 
 func (i IntValue) String() string {
 	return strconv.Itoa(int(i))
+}
+
+// TimeValue is used to represent socket options with a duration value.
+type TimeValue Timestamp
+
+func (TimeValue) sockopt() {}
+
+func (tv TimeValue) String() string {
+	return time.Duration(tv).String()
 }
 
 // SocketsNotSupported is a helper type intended to be embeded in


### PR DESCRIPTION
This PR adds more tests to verify the behavior of sockets in blocking mode; they are copies of tests used in non-blocking mode with the `poll_oneoff` calls removed.

I aloso implemented `SO_RCVTIMEO` and `SO_SNDTIMEO` since those options apply to blocking mode.