### PR TITLE
addrinfo: use default resolver

### DIFF
--- a/cmd/wasirun/main.go
+++ b/cmd/wasirun/main.go
@@ -34,13 +34,13 @@ OPTIONS:
    --dir <DIR>
       Grant access to the specified host directory
 
-   --listen <ADDR>
+   --listen <ADDR:PORT>
       Grant access to a socket listening on the specified address
 
-   --dial <ADDR[:PORT]>
+   --dial <ADDR:PORT>
       Grant access to a socket connected to the specified address
 
-   --dns-server <ADDR>
+   --dns-server <ADDR:PORT>
       Sets the address of the DNS server to use for name resolution
 
    --env <NAME=VAL>
@@ -50,7 +50,7 @@ OPTIONS:
       Enable a sockets extension, either {none, auto, path_open,
       wasmedgev1, wasmedgev2}
 
-   --pprof-addr <ADDR>
+   --pprof-addr <ADDR:PORT>
       Start a pprof server listening on the specified address
 
    --trace

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,4 @@ require (
 	golang.org/x/sys v0.8.0
 )
 
-require golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
+require golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1

--- a/imports/wasi_snapshot_preview1/wasmedge.go
+++ b/imports/wasi_snapshot_preview1/wasmedge.go
@@ -3,7 +3,6 @@ package wasi_snapshot_preview1
 import (
 	"context"
 	"encoding/binary"
-	"fmt"
 	"io"
 	"unsafe"
 
@@ -280,8 +279,6 @@ func (m *Module) WasmEdgeSockAddrInfo(ctx context.Context, name String, service 
 	count := 0
 	for _, addrinfo := range m.addrinfo[:n] {
 		res := resPtr.Load()
-		fmt.Printf("result pointer = %#v\n", resPtr)
-		fmt.Printf("next pointer   = %#v\n", res.Next)
 		if res.Address == 0 {
 			return Errno(wasi.EFAULT)
 		}


### PR DESCRIPTION
This PR modifies `wasirun` to use `net.DefaultResolver` so we can configure the DNS servers for `SockAddressInfo` and propagate the context for asynchronous cancellation.