### PR TITLE
wasi: add FileTable.PreopenFD method

### DIFF
--- a/wasi.go
+++ b/wasi.go
@@ -126,6 +126,10 @@ func (t *FileTable[T]) Preopen(file T, path string, stat FDStat) FD {
 	return fd
 }
 
+func (t *FileTable[T]) PreopenFD(fd FD) {
+	t.preopens.Assign(fd, "")
+}
+
 func (t *FileTable[T]) Register(file T, stat FDStat) FD {
 	stat.RightsBase &= AllRights
 	stat.RightsInheriting &= AllRights


### PR DESCRIPTION
This PR adds a method to `wasi.FileTable` to support declaring an open file descriptor as a preopen. This is useful when performing initialization of the `wasi.System` prior to instantiating a module, and the host needs to configure the file descriptors it created as preopens.