### PR TITLE
socket: long options

### DIFF
--- a/imports/wasi_snapshot_preview1/wasmedge.go
+++ b/imports/wasi_snapshot_preview1/wasmedge.go
@@ -132,7 +132,7 @@ func (m *Module) WasmEdgeV2SockRecvFrom(ctx context.Context, fd Int32, iovecs Li
 }
 
 func (m *Module) WasmEdgeSockSetOpt(ctx context.Context, fd Int32, level Int32, option Int32, value Bytes) Errno {
-	opt := wasi.SocketOption((int64(level) << 32) | int64(option))
+	opt := wasi.MakeSocketOption(wasi.SocketOptionLevel(level), int32(option))
 
 	var val wasi.SocketOptionValue
 	switch opt {
@@ -160,14 +160,14 @@ func (m *Module) WasmEdgeSockSetOpt(ctx context.Context, fd Int32, level Int32, 
 		return Errno(wasi.ENOTSUP)
 
 	default:
-		val = wasi.StringValue(value)
+		val = wasi.BytesValue(value)
 	}
 
 	return Errno(m.WASI.SockSetOpt(ctx, wasi.FD(fd), opt, val))
 }
 
 func (m *Module) WasmEdgeSockGetOpt(ctx context.Context, fd Int32, level Int32, option Int32, value Pointer[Int32], valueLen Int32) Errno {
-	opt := wasi.SocketOption((int64(level) << 32) | int64(option))
+	opt := wasi.MakeSocketOption(wasi.SocketOptionLevel(level), int32(option))
 
 	// Only int options are supported for now.
 	switch opt {

--- a/socket.go
+++ b/socket.go
@@ -318,14 +318,19 @@ func (st SocketType) String() string {
 type SocketOptionLevel int32
 
 const (
-	SocketLevel SocketOptionLevel = 0 // SOL_SOCKET
-	TcpLevel    SocketOptionLevel = 6 // IPPROTO_TCP
+	SocketLevel   SocketOptionLevel = 0 // SOL_SOCKET
+	TcpLevel      SocketOptionLevel = 6 // IPPROTO_TCP
+	ReservedLevel SocketOptionLevel = 0x74696d65
 )
 
 func (sl SocketOptionLevel) String() string {
 	switch sl {
 	case SocketLevel:
 		return "SocketLevel"
+	case TcpLevel:
+		return "TcpLevel"
+	case ReservedLevel:
+		return "ReservedLevel"
 	default:
 		return fmt.Sprintf("SocketOptionLevel(%d)", sl)
 	}
@@ -354,6 +359,8 @@ const (
 
 	// 0x1000 + iota are IPPROTO_TCP level options.
 	TcpNoDelay SocketOption = 0x1000 + iota
+
+	// >= 0x9000 are reserved.
 )
 
 func (so SocketOption) String() string {
@@ -478,6 +485,15 @@ func (TimeValue) sockopt() {}
 
 func (tv TimeValue) String() string {
 	return time.Duration(tv).String()
+}
+
+// StringValue is used to represent an arbitrary socket option value.
+type StringValue string
+
+func (StringValue) sockopt() {}
+
+func (s StringValue) String() string {
+	return string(s)
 }
 
 // SocketsNotSupported is a helper type intended to be embeded in

--- a/socket.go
+++ b/socket.go
@@ -318,9 +318,8 @@ func (st SocketType) String() string {
 type SocketOptionLevel int32
 
 const (
-	SocketLevel   SocketOptionLevel = 0 // SOL_SOCKET
-	TcpLevel      SocketOptionLevel = 6 // IPPROTO_TCP
-	ReservedLevel SocketOptionLevel = 0x74696d65
+	SocketLevel SocketOptionLevel = 0 // SOL_SOCKET
+	TcpLevel    SocketOptionLevel = 6 // IPPROTO_TCP
 )
 
 func (sl SocketOptionLevel) String() string {

--- a/socket.go
+++ b/socket.go
@@ -340,6 +340,10 @@ func (s SocketOption) Level() SocketOptionLevel {
 	return SocketOptionLevel(s >> 32)
 }
 
+func MakeSocketOption(level SocketOptionLevel, option int32) SocketOption {
+	return (SocketOption(level) << 32) | SocketOption(option)
+}
+
 // SOL_SOCKET level options.
 const (
 	ReuseAddress SocketOption = (SocketOption(SocketLevel) << 32) | iota
@@ -488,12 +492,12 @@ func (tv TimeValue) String() string {
 	return time.Duration(tv).String()
 }
 
-// StringValue is used to represent an arbitrary socket option value.
-type StringValue string
+// BytesValue is used to represent an arbitrary socket option value.
+type BytesValue []byte
 
-func (StringValue) sockopt() {}
+func (BytesValue) sockopt() {}
 
-func (s StringValue) String() string {
+func (s BytesValue) String() string {
 	return string(s)
 }
 

--- a/socket.go
+++ b/socket.go
@@ -329,19 +329,21 @@ func (sl SocketOptionLevel) String() string {
 		return "SocketLevel"
 	case TcpLevel:
 		return "TcpLevel"
-	case ReservedLevel:
-		return "ReservedLevel"
 	default:
 		return fmt.Sprintf("SocketOptionLevel(%d)", sl)
 	}
 }
 
 // SocketOption is a socket option that can be queried or set.
-type SocketOption int32
+type SocketOption int64
 
+func (s SocketOption) Level() SocketOptionLevel {
+	return SocketOptionLevel(s >> 32)
+}
+
+// SOL_SOCKET level options.
 const (
-	// SOL_SOCKET level options.
-	ReuseAddress SocketOption = iota
+	ReuseAddress SocketOption = (SocketOption(SocketLevel) << 32) | iota
 	QuerySocketType
 	QuerySocketError
 	DontRoute
@@ -356,11 +358,11 @@ const (
 	SendTimeout
 	QueryAcceptConnections
 	BindToDevice
+)
 
-	// 0x1000 + iota are IPPROTO_TCP level options.
-	TcpNoDelay SocketOption = 0x1000 + iota
-
-	// >= 0x9000 are reserved.
+// IPPROTO_TCP level options
+const (
+	TcpNoDelay SocketOption = (SocketOption(TcpLevel) << 32) | (15)
 )
 
 func (so SocketOption) String() string {
@@ -398,7 +400,7 @@ func (so SocketOption) String() string {
 	case TcpNoDelay:
 		return "TcpNoDelay"
 	default:
-		return fmt.Sprintf("SocketOption(%d)", so)
+		return fmt.Sprintf("SocketOption(%d|%d)", so.Level(), int32(so))
 	}
 }
 

--- a/system.go
+++ b/system.go
@@ -363,12 +363,12 @@ type System interface {
 	// SockGetOpt gets a socket option.
 	//
 	// Note: This is similar to getsockopt in POSIX.
-	SockGetOpt(ctx context.Context, fd FD, level SocketOptionLevel, option SocketOption) (SocketOptionValue, Errno)
+	SockGetOpt(ctx context.Context, fd FD, option SocketOption) (SocketOptionValue, Errno)
 
 	// SockSetOpt sets a socket option.
 	//
 	// Note: This is similar to setsockopt in POSIX.
-	SockSetOpt(ctx context.Context, fd FD, level SocketOptionLevel, option SocketOption, value SocketOptionValue) Errno
+	SockSetOpt(ctx context.Context, fd FD, option SocketOption, value SocketOptionValue) Errno
 
 	// SockLocalAddress gets the local address of the socket.
 	//

--- a/systems/unix/system.go
+++ b/systems/unix/system.go
@@ -669,14 +669,14 @@ func (s *System) SockRecvFrom(ctx context.Context, fd wasi.FD, iovecs []wasi.IOV
 	}
 }
 
-func (s *System) SockGetOpt(ctx context.Context, fd wasi.FD, level wasi.SocketOptionLevel, option wasi.SocketOption) (wasi.SocketOptionValue, wasi.Errno) {
+func (s *System) SockGetOpt(ctx context.Context, fd wasi.FD, option wasi.SocketOption) (wasi.SocketOptionValue, wasi.Errno) {
 	socket, _, errno := s.LookupSocketFD(fd, 0)
 	if errno != wasi.ESUCCESS {
 		return nil, errno
 	}
 
 	var sysLevel int
-	switch level {
+	switch option.Level() {
 	case wasi.SocketLevel:
 		sysLevel = unix.SOL_SOCKET
 	case wasi.TcpLevel:
@@ -769,14 +769,14 @@ func (s *System) SockGetOpt(ctx context.Context, fd wasi.FD, level wasi.SocketOp
 	return wasi.IntValue(value), errno
 }
 
-func (s *System) SockSetOpt(ctx context.Context, fd wasi.FD, level wasi.SocketOptionLevel, option wasi.SocketOption, value wasi.SocketOptionValue) wasi.Errno {
+func (s *System) SockSetOpt(ctx context.Context, fd wasi.FD, option wasi.SocketOption, value wasi.SocketOptionValue) wasi.Errno {
 	socket, _, errno := s.LookupSocketFD(fd, 0)
 	if errno != wasi.ESUCCESS {
 		return errno
 	}
 
 	var sysLevel int
-	switch level {
+	switch option.Level() {
 	case wasi.SocketLevel:
 		sysLevel = unix.SOL_SOCKET
 	case wasi.TcpLevel:

--- a/tracer.go
+++ b/tracer.go
@@ -680,9 +680,9 @@ func (t *tracer) SockRecvFrom(ctx context.Context, fd FD, iovecs []IOVec, iflags
 	return n, oflags, addr, errno
 }
 
-func (t *tracer) SockGetOpt(ctx context.Context, fd FD, level SocketOptionLevel, option SocketOption) (SocketOptionValue, Errno) {
-	t.printf("SockGetOpt(%d, %s, %s) => ", fd, level, option)
-	value, errno := t.system.SockGetOpt(ctx, fd, level, option)
+func (t *tracer) SockGetOpt(ctx context.Context, fd FD, option SocketOption) (SocketOptionValue, Errno) {
+	t.printf("SockGetOpt(%d, %s) => ", fd, option)
+	value, errno := t.system.SockGetOpt(ctx, fd, option)
 	if errno == ESUCCESS {
 		t.printf("%d", value)
 	} else {
@@ -692,9 +692,9 @@ func (t *tracer) SockGetOpt(ctx context.Context, fd FD, level SocketOptionLevel,
 	return value, errno
 }
 
-func (t *tracer) SockSetOpt(ctx context.Context, fd FD, level SocketOptionLevel, option SocketOption, value SocketOptionValue) Errno {
-	t.printf("SockSetOpt(%d, %s, %s, %d) => ", fd, level, option, value)
-	errno := t.system.SockSetOpt(ctx, fd, level, option, value)
+func (t *tracer) SockSetOpt(ctx context.Context, fd FD, option SocketOption, value SocketOptionValue) Errno {
+	t.printf("SockSetOpt(%d, %s, %s) => ", fd, option, value)
+	errno := t.system.SockSetOpt(ctx, fd, option, value)
 	if errno == ESUCCESS {
 		t.printf("ok")
 	} else {


### PR DESCRIPTION
This patch makes two main changes:

- Allow options of variable lengths to be passed through `SockSetOpt`.
- Modify `SockSetOpt` and `SockGetOpt` to merge option and level into one value.

The main goal is to enable extensions of socket options by the implementations of `wasi.System`, without having to teach wasi-go about them.