### PR TITLE
limit open files and directories

### DIFF
--- a/cmd/wasirun/main.go
+++ b/cmd/wasirun/main.go
@@ -64,6 +64,12 @@ OPTIONS:
    --non-blocking-stdio
       Enable non-blocking stdio
 
+   --max-open-files <N>
+      Limit the number of files that may be opened by the module
+
+   --max-open-dirs <N>
+      Limit the number of directories that may be opened by the module
+
    --http <MODE>
       Optionally enable wasi-http client support and select a
       version {none, auto, v1}
@@ -89,6 +95,8 @@ var (
 	trace            bool
 	nonBlockingStdio bool
 	version          bool
+	maxOpenFiles     int
+	maxOpenDirs      int
 )
 
 func main() {
@@ -108,6 +116,8 @@ func main() {
 	flagSet.BoolVar(&nonBlockingStdio, "non-blocking-stdio", false, "")
 	flagSet.BoolVar(&version, "version", false, "")
 	flagSet.BoolVar(&version, "v", false, "")
+	flagSet.IntVar(&maxOpenFiles, "max-open-files", 1024, "")
+	flagSet.IntVar(&maxOpenDirs, "max-open-dirs", 1024, "")
 	flagSet.Parse(os.Args[1:])
 
 	if version {
@@ -190,7 +200,9 @@ func run(wasmFile string, args []string) error {
 		WithDials(dials...).
 		WithNonBlockingStdio(nonBlockingStdio).
 		WithSocketsExtension(socketExt, wasmModule).
-		WithTracer(trace, os.Stderr)
+		WithTracer(trace, os.Stderr).
+		WithMaxOpenFiles(maxOpenFiles).
+		WithMaxOpenDirs(maxOpenDirs)
 
 	var system wasi.System
 	ctx, system, err = builder.Instantiate(ctx, runtime)

--- a/imports/builder.go
+++ b/imports/builder.go
@@ -39,6 +39,8 @@ type Builder struct {
 	decorators         []wasi_snapshot_preview1.Decorator
 	wrappers           []func(wasi.System) wasi.System
 	errors             []error
+	maxOpenFiles       int
+	maxOpenDirs        int
 }
 
 // NewBuilder creates a Builder.
@@ -213,5 +215,19 @@ func (b *Builder) WithDecorators(decorators ...wasi_snapshot_preview1.Decorator)
 // WithWrappers sets the wasi.System wrappers.
 func (b *Builder) WithWrappers(wrappers ...func(wasi.System) wasi.System) *Builder {
 	b.wrappers = wrappers
+	return b
+}
+
+// WithMaxOpenFiles sets the limit on the maximum number of files that may be
+// opened by the guest module.
+func (b *Builder) WithMaxOpenFiles(n int) *Builder {
+	b.maxOpenFiles = n
+	return b
+}
+
+// WithMaxOpenFiles sets the limit on the maximum number of directories that may
+// be opened by the guest module.
+func (b *Builder) WithMaxOpenDirs(n int) *Builder {
+	b.maxOpenDirs = n
 	return b
 }

--- a/imports/builder_unix.go
+++ b/imports/builder_unix.go
@@ -80,6 +80,9 @@ func (b *Builder) Instantiate(ctx context.Context, runtime wazero.Runtime) (ctxr
 		Rand:               rand,
 		Exit:               exit,
 	}
+	unixSystem.MaxOpenFiles = b.maxOpenFiles
+	unixSystem.MaxOpenDirs = b.maxOpenDirs
+
 	system := wasi.System(unixSystem)
 	defer func() {
 		if system != nil {

--- a/systems/unix/file.go
+++ b/systems/unix/file.go
@@ -116,6 +116,11 @@ func (fd FD) FDWrite(ctx context.Context, iovecs []wasi.IOVec) (wasi.Size, wasi.
 }
 
 func (fd FD) FDOpenDir(ctx context.Context) (wasi.Dir, wasi.Errno) {
+	if _, err := ignoreEINTR2(func() (int64, error) {
+		return lseek(int(fd), 0, 0)
+	}); err != nil {
+		return nil, makeErrno(err)
+	}
 	return &dirbuf{fd: int(fd)}, wasi.ESUCCESS
 }
 

--- a/systems/unix/system_test.go
+++ b/systems/unix/system_test.go
@@ -69,6 +69,8 @@ func makeSystem(config wasitest.TestConfig) (wasi.System, error) {
 			panic(sys.NewExitError(127 + uint32(code)))
 		},
 	}
+	s.MaxOpenFiles = config.MaxOpenFiles
+	s.MaxOpenDirs = config.MaxOpenDirs
 	defer func() {
 		if s != nil {
 			s.Close(context.Background())

--- a/wasitest/file.go
+++ b/wasitest/file.go
@@ -1,0 +1,69 @@
+package wasitest
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stealthrocket/wasi-go"
+)
+
+var file = testSuite{
+	"exceeding the limit of open files":       testMaxOpenFiles,
+	"exceeding the limit of open directories": testMaxOpenDirs,
+}
+
+func testMaxOpenFiles(t *testing.T, ctx context.Context, newSystem newSystem) {
+	tmp := t.TempDir()
+	sys := newSystem(TestConfig{
+		RootFS:       tmp,
+		MaxOpenFiles: 10,
+	})
+
+	for i := 0; i < 10; i++ {
+		_, errno := sys.PathOpen(ctx, 3, 0, ".", wasi.OpenDirectory, wasi.AllRights, wasi.AllRights, 0)
+		if errno == wasi.ENFILE {
+			break
+		}
+		assertEqual(t, errno, wasi.ESUCCESS)
+	}
+
+	for i := 0; i < 10; i++ {
+		_, errno := sys.PathOpen(ctx, 3, 0, ".", wasi.OpenDirectory, wasi.AllRights, wasi.AllRights, 0)
+		assertEqual(t, errno, wasi.ENFILE)
+	}
+}
+
+func testMaxOpenDirs(t *testing.T, ctx context.Context, newSystem newSystem) {
+	tmp := t.TempDir()
+	sys := newSystem(TestConfig{
+		RootFS:      tmp,
+		MaxOpenDirs: 10,
+	})
+
+	assertOK(t, os.WriteFile(filepath.Join(tmp, "file-1"), []byte("1"), 0666))
+	assertOK(t, os.WriteFile(filepath.Join(tmp, "file-2"), []byte("2"), 0666))
+	assertOK(t, os.WriteFile(filepath.Join(tmp, "file-3"), []byte("3"), 0666))
+
+	for i := 0; i < 10; i++ {
+		d, errno := sys.PathOpen(ctx, 3, 0, ".", wasi.OpenDirectory, wasi.AllRights, wasi.AllRights, 0)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		dirEntry := [1]wasi.DirEntry{}
+		n, errno := sys.FDReadDir(ctx, d, dirEntry[:], 0, 1024)
+		assertEqual(t, n, 1)
+		assertEqual(t, errno, wasi.ESUCCESS)
+	}
+
+	for i := 0; i < 10; i++ {
+		d, errno := sys.PathOpen(ctx, 3, 0, ".", wasi.OpenDirectory, wasi.AllRights, wasi.AllRights, 0)
+		assertEqual(t, errno, wasi.ESUCCESS)
+
+		dirEntry := [1]wasi.DirEntry{}
+		n, errno := sys.FDReadDir(ctx, d, dirEntry[:], 0, 1024)
+		assertEqual(t, n, 0)
+		assertEqual(t, errno, wasi.ENFILE)
+		assertEqual(t, sys.FDClose(ctx, d), wasi.ESUCCESS)
+	}
+}

--- a/wasitest/system.go
+++ b/wasitest/system.go
@@ -12,6 +12,7 @@ import (
 // TestSystem is a test suite which validates the behavior of wasi.System
 // implementations.
 func TestSystem(t *testing.T, makeSystem MakeSystem) {
+	t.Run("file", file.runFunc(makeSystem))
 	t.Run("proc", proc.runFunc(makeSystem))
 	t.Run("poll", poll.runFunc(makeSystem))
 	t.Run("socket", socket.runFunc(makeSystem))

--- a/wasitest/wasip1.go
+++ b/wasitest/wasip1.go
@@ -28,6 +28,9 @@ type TestConfig struct {
 	Rand    io.Reader
 	RootFS  string
 	Now     func() time.Time
+	// Limits, zero means none.
+	MaxOpenFiles int
+	MaxOpenDirs  int
 }
 
 // MakeSystem is a function used to create a system to run the test suites


### PR DESCRIPTION
This PR adds two settings on the `wasi.FileTable` data structure to limit the number of open files and directories.