### PR TITLE
Pass context to fix calls to wasip1

### DIFF
--- a/cmd/wasirun/main.go
+++ b/cmd/wasirun/main.go
@@ -249,7 +249,7 @@ func run(wasmFile string, args []string) error {
 		return err
 	}
 	if len(wasiHttpAddr) > 0 {
-		handler := wasiHTTP.MakeHandler(instance)
+		handler := wasiHTTP.MakeHandler(ctx, instance)
 		http.Handle(wasiHttpPath, handler)
 		return http.ListenAndServe(wasiHttpAddr, nil)
 	}

--- a/imports/wasi_http/http.go
+++ b/imports/wasi_http/http.go
@@ -65,17 +65,13 @@ func DetectWasiHttp(module wazero.CompiledModule) bool {
 	return hasWasiHttp
 }
 
-func (w *WasiHTTP) MakeHandler(m api.Module) http.Handler {
+func (w *WasiHTTP) MakeHandler(ctx context.Context, m api.Module) http.Handler {
 	return server.WasmServer{
+		Ctx:       ctx,
 		Module:    m,
 		Requests:  w.r,
 		Responses: w.rs,
 		Fields:    w.f,
 		OutParams: w.o,
 	}
-}
-
-func (w *WasiHTTP) HandleHTTP(writer http.ResponseWriter, req *http.Request, m api.Module) {
-	handler := w.MakeHandler(m)
-	handler.ServeHTTP(writer, req)
 }

--- a/imports/wasi_http/http_test.go
+++ b/imports/wasi_http/http_test.go
@@ -185,7 +185,7 @@ func TestServer(t *testing.T) {
 				}
 			}
 			if instance != nil {
-				h := w.MakeHandler(instance)
+				h := w.MakeHandler(ctx, instance)
 				s := httptest.NewServer(h)
 				defer s.Close()
 

--- a/imports/wasi_http/server/server.go
+++ b/imports/wasi_http/server/server.go
@@ -9,6 +9,7 @@ import (
 )
 
 type WasmServer struct {
+	Ctx       context.Context
 	Module    api.Module
 	Fields    *types.FieldsCollection
 	Requests  *types.Requests
@@ -26,7 +27,7 @@ func (w WasmServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	id := w.Requests.MakeRequest(req)
 	out := w.OutParams.MakeOutparameter()
 
-	_, err := fn.Call(context.TODO(), uint64(id), uint64(out))
+	_, err := fn.Call(w.Ctx, uint64(id), uint64(out))
 	if err != nil {
 		res.WriteHeader(500)
 		res.Write([]byte(err.Error()))


### PR DESCRIPTION
This fixes a bug where calls to wasi functions (e.g. `printf`) would crash.