### PR TITLE
wasi: support empty getaddrinfo name without AI_PASSIVE

### DIFF
--- a/systems/unix/system.go
+++ b/systems/unix/system.go
@@ -1003,13 +1003,18 @@ func (s *System) SockAddressInfo(ctx context.Context, name, service string, hint
 			return 0, wasi.EINVAL
 		}
 	} else if name == "" {
-		if !hints.Flags.Has(wasi.Passive) {
-			return 0, wasi.EINVAL
-		}
-		if hints.Family == wasi.Inet6Family {
-			ip = net.IPv6zero
+		if hints.Flags.Has(wasi.Passive) {
+			if hints.Family == wasi.Inet6Family {
+				ip = net.IPv6zero
+			} else {
+				ip = net.IPv4zero
+			}
 		} else {
-			ip = net.IPv4zero
+			if hints.Family == wasi.Inet6Family {
+				ip = net.IPv6loopback
+			} else {
+				ip = net.IPv4(127, 0, 0, 1)
+			}
 		}
 	}
 


### PR DESCRIPTION
From `getaddrinfo(3)`:

> If the AI_PASSIVE flag is specified in hints.ai_flags, and node is NULL, then the returned socket addresses will be suitable for bind(2)ing a socket that will accept(2) connections. The returned socket address will contain the "wildcard address" (INADDR_ANY for IPv4 addresses, IN6ADDR_ANY_INIT for IPv6 address).  The wildcard address is used by applications (typically servers) that intend to accept connections on any of the host's network addresses. If node is not NULL, then the AI_PASSIVE flag is ignored.

> If the AI_PASSIVE flag is not set in hints.ai_flags, then the returned socket addresses will be suitable for use with connect(2), sendto(2), or sendmsg(2). If node is NULL, then the network address will be set to the loopback interface address (INADDR_LOOPBACK for IPv4 addresses, IN6ADDR_LOOPBACK_INIT for IPv6 address); this is used by applications that intend to communicate with peers running on the same host.
