### PR TITLE
Same signature both for Unix and Windows

### DIFF
--- a/imports/builder_default.go
+++ b/imports/builder_default.go
@@ -11,6 +11,6 @@ import (
 	"github.com/tetratelabs/wazero"
 )
 
-func (b *Builder) Instantiate(ctx context.Context, _ wazero.Runtime) (ctxret context.Context, sys wasi.System, err error) {
+func (b *Builder) Instantiate(ctx context.Context, _ wazero.Runtime) (context.Context, wasi.System, error) {
 	return ctx, nil, fmt.Errorf("wasi-go is not available on GOOS=%s", runtime.GOOS)
 }

--- a/imports/builder_default.go
+++ b/imports/builder_default.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/stealthrocket/wasi-go"
 	"github.com/tetratelabs/wazero"
 )
 
-func (b *Builder) Instantiate(ctx context.Context, _ wazero.Runtime) (context.Context, error) {
-	return ctx, fmt.Errorf("wasi-go is not available on GOOS=%s", runtime.GOOS)
+func (b *Builder) Instantiate(ctx context.Context, _ wazero.Runtime) (ctxret context.Context, sys wasi.System, err error) {
+	return ctx, nil, fmt.Errorf("wasi-go is not available on GOOS=%s", runtime.GOOS)
 }


### PR DESCRIPTION
Some existing codebase under Unix was using builder.Instanciate() that returns 3 values.
My IDE was complaining because it was expecting only 2 values returned.

It turns out: I should simply not try to compile it under Windows.
Signatures both for the `default` and the `_unix` should be the same to avoid such error. 